### PR TITLE
`DateUtil#parseByFormat` / `parseByTimestamp` 구현

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -219,6 +219,39 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('parseByFormat', () => {
+    it('should throw error when invalid arguments given', () => {
+      expect(() => DateUtil.parseByFormat('20210131', 'YYYYM')).toThrow();
+      expect(() => DateUtil.parseByFormat('20210131', 'YYYYMMDDHHmmssSSSS')).not.toThrow();
+    });
+
+    it('should return valid date', () => {
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmssSSS')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('08202121001122', 'MMYYYYDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('24/12/2019 11:15:00', 'DD/MM/YYYY HH:mm:ss')).toEqual(
+        new Date('2019-12-24 11:15:00')
+      );
+    });
+  });
+  describe('parseByFormat', () => {
+    it('should throw error when invalid arguments given', () => {
+      expect(() => DateUtil.parseByFormat('20210131', 'YYYYM')).toThrow();
+      expect(() => DateUtil.parseByFormat('20210131', 'YYYYMMDDHHmmssSSSS')).not.toThrow();
+    });
+
+    it('should return valid date', () => {
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmssSSS')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('08202121001122', 'MMYYYYDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseByFormat('24/12/2019 11:15:00', 'DD/MM/YYYY HH:mm:ss')).toEqual(
+        new Date('2019-12-24 11:15:00')
+      );
+    });
+  });
+
   describe('parseTimestamp', () => {
     it('should throw error when invalid arguments given', () => {
       expect(() => DateUtil.parseTimestamp('20210131')).not.toThrow();

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -218,4 +218,25 @@ describe('DateUtil', () => {
       );
     });
   });
+
+  describe('parseTimestamp', () => {
+    it('should throw error when invalid arguments given', () => {
+      expect(() => DateUtil.parseTimestamp('2021', 'YYYYM')).toThrow();
+    });
+
+    it('should return valid date', () => {
+      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseTimestamp('08202121001122', 'MMYYYYDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseTimestamp('24/12/2019 11:15:00', 'DD/MM/YYYY HH:mm:ss')).toEqual(
+        new Date('2019-12-24 11:15:00')
+      );
+      expect(DateUtil.parseTimestamp('21 24/12/2019 11:15:00', 'DD DD/MM/YYYY HH:mm:ss')).toEqual(
+        new Date('2019-12-24 11:15:00')
+      );
+      expect(DateUtil.parseTimestamp('20210821111122.123456', 'YYYYMMDDHHmmss.SSSSSS')).toEqual(
+        new Date('2021-08-21 11:11:22.123')
+      );
+      expect(DateUtil.parseTimestamp('2021/8/1 3:9:1', 'YYYY/M/D H:m:s')).toEqual(new Date('2021-08-01 03:09:01'));
+    });
+  });
 });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -221,25 +221,14 @@ describe('DateUtil', () => {
 
   describe('parseTimestamp', () => {
     it('should throw error when invalid arguments given', () => {
-      expect(() => DateUtil.parseTimestamp('20210131', 'YYYYM')).toThrow();
-      expect(() => DateUtil.parseTimestamp('20210131', 'YYYYMMDDHHmmssSSSS')).not.toThrow();
+      expect(() => DateUtil.parseTimestamp('20210131')).not.toThrow();
+      expect(() => DateUtil.parseTimestamp('2021013111223344112233')).toThrow();
     });
 
     it('should return valid date', () => {
-      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
-      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmssSSS')).toEqual(new Date('2021-08-21 00:11:22'));
-      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
-      expect(DateUtil.parseTimestamp('08202121001122', 'MMYYYYDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
-      expect(DateUtil.parseTimestamp('24/12/2019 11:15:00', 'DD/MM/YYYY HH:mm:ss')).toEqual(
-        new Date('2019-12-24 11:15:00')
-      );
-      expect(DateUtil.parseTimestamp('21 24/12/2019 11:15:00', 'DD DD/MM/YYYY HH:mm:ss')).toEqual(
-        new Date('2019-12-24 11:15:00')
-      );
-      expect(DateUtil.parseTimestamp('20210821111122.123456', 'YYYYMMDDHHmmss.SSSSSS')).toEqual(
-        new Date('2021-08-21 11:11:22.123')
-      );
-      expect(DateUtil.parseTimestamp('2021/8/1 3:9:1', 'YYYY/M/D H:m:s')).toEqual(new Date('2021-08-01 03:09:01'));
+      expect(DateUtil.parseTimestamp('20210821')).toEqual(new Date('2021-08-21 00:00:00'));
+      expect(DateUtil.parseTimestamp('20210821001122')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseTimestamp('20210821001122123')).toEqual(new Date('2021-08-21 00:11:22.123'));
     });
   });
 });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -221,10 +221,13 @@ describe('DateUtil', () => {
 
   describe('parseTimestamp', () => {
     it('should throw error when invalid arguments given', () => {
-      expect(() => DateUtil.parseTimestamp('2021', 'YYYYM')).toThrow();
+      expect(() => DateUtil.parseTimestamp('20210131', 'YYYYM')).toThrow();
+      expect(() => DateUtil.parseTimestamp('20210131', 'YYYYMMDDHHmmssSSSS')).not.toThrow();
     });
 
     it('should return valid date', () => {
+      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
+      expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmssSSS')).toEqual(new Date('2021-08-21 00:11:22'));
       expect(DateUtil.parseTimestamp('20210821001122', 'YYYYMMDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
       expect(DateUtil.parseTimestamp('08202121001122', 'MMYYYYDDHHmmss')).toEqual(new Date('2021-08-21 00:11:22'));
       expect(DateUtil.parseTimestamp('24/12/2019 11:15:00', 'DD/MM/YYYY HH:mm:ss')).toEqual(

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -143,7 +143,9 @@ export namespace DateUtil {
     return min;
   }
 
-  export function parseTimestamp(str: string, fmt = 'YYYYMMDDHHmmssSSS'): Date {
+  export function parseTimestamp(str: string): Date {
+    const fmt = 'YYYYMMDDHHmmssSSS';
+
     if (str.length > fmt.length) {
       throw new Error(`Invalid Arguments: str and fmt are not matched. str: ${str}, fmt: ${fmt}`);
     }
@@ -205,9 +207,9 @@ export namespace DateUtil {
         },
       ],
       [
-        'S{1,9}',
+        'S?S?S',
         (match, date) => {
-          date.setMilliseconds(parseInt(substrByMatch(match)) / 1000);
+          date.setMilliseconds(parseInt(substrByMatch(match)));
           return date;
         },
       ],

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -144,7 +144,7 @@ export namespace DateUtil {
   }
 
   export function parseTimestamp(str: string, fmt = 'YYYYMMDDHHmmssSSS'): Date {
-    if (str.length !== fmt.length) {
+    if (str.length > fmt.length) {
       throw new Error(`Invalid Arguments: str and fmt are not matched. str: ${str}, fmt: ${fmt}`);
     }
 
@@ -154,9 +154,14 @@ export namespace DateUtil {
 
     function substrByMatch(match: RegExpMatchArray): string {
       if (match.index !== undefined) {
-        return str.substr(match.index, match[0].length);
+        const val = str.substr(match.index, match[0].length);
+        if (val.length > 0) {
+          return val;
+        } else {
+          return '0';
+        }
       } else {
-        return '';
+        return '0';
       }
     }
 

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -143,9 +143,7 @@ export namespace DateUtil {
     return min;
   }
 
-  export function parseTimestamp(str: string): Date {
-    const fmt = 'YYYYMMDDHHmmssSSS';
-
+  export function parseByFormat(str: string, fmt: string): Date {
     if (str.length > fmt.length) {
       throw new Error(`Invalid Arguments: str and fmt are not matched. str: ${str}, fmt: ${fmt}`);
     }
@@ -225,5 +223,9 @@ export namespace DateUtil {
     }
 
     return retDate;
+  }
+
+  export function parseTimestamp(str: string): Date {
+    return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
   }
 }

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -153,13 +153,9 @@ export namespace DateUtil {
     }
 
     function substrByMatch(match: RegExpMatchArray): string {
-      if (match.index !== undefined) {
-        const val = str.substr(match.index, match[0].length);
-        if (val.length > 0) {
-          return val;
-        } else {
-          return '0';
-        }
+      const val = str.substr(<number>match.index, match[0].length);
+      if (val.length > 0) {
+        return val;
       } else {
         return '0';
       }

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -142,4 +142,85 @@ export namespace DateUtil {
     }
     return min;
   }
+
+  export function parseTimestamp(str: string, fmt = 'YYYYMMDDHHmmssSSS'): Date {
+    if (str.length !== fmt.length) {
+      throw new Error(`Invalid Arguments: str and fmt are not matched. str: ${str}, fmt: ${fmt}`);
+    }
+
+    interface Callback {
+      (matched: RegExpMatchArray, date: Date): Date;
+    }
+
+    function substrByMatch(match: RegExpMatchArray): string {
+      if (match.index !== undefined) {
+        return str.substr(match.index, match[0].length);
+      } else {
+        return '';
+      }
+    }
+
+    const tokenCallbackMap = new Map<string, Callback>([
+      [
+        'YYYY',
+        (match, date) => {
+          date.setFullYear(parseInt(substrByMatch(match)));
+          return date;
+        },
+      ],
+      [
+        'M?M',
+        (match, date) => {
+          date.setMonth(parseInt(substrByMatch(match)) - 1);
+          return date;
+        },
+      ],
+      [
+        'D?D',
+        (match, date) => {
+          date.setDate(parseInt(substrByMatch(match)));
+          return date;
+        },
+      ],
+      [
+        'H?H',
+        (match, date) => {
+          date.setHours(parseInt(substrByMatch(match)));
+          return date;
+        },
+      ],
+      [
+        'm?m',
+        (match, date) => {
+          date.setMinutes(parseInt(substrByMatch(match)));
+          return date;
+        },
+      ],
+      [
+        's?s',
+        (match, date) => {
+          date.setSeconds(parseInt(substrByMatch(match)));
+          return date;
+        },
+      ],
+      [
+        'S{1,9}',
+        (match, date) => {
+          date.setMilliseconds(parseInt(substrByMatch(match)) / 1000);
+          return date;
+        },
+      ],
+    ]);
+
+    let retDate = new Date(0);
+    for (const [token, callback] of tokenCallbackMap.entries()) {
+      const pattern = new RegExp(token, 'g');
+
+      for (const match of fmt.matchAll(pattern)) {
+        retDate = callback(match, retDate);
+      }
+    }
+
+    return retDate;
+  }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://fastcampus.atlassian.net/browse/PF-28
- Redstone(JS)에서 `parseTimestamp`가 여러곳에서 사용되는 것을 확인하여 구현함.

## 무엇을 어떻게 변경했나요?
- token으로 `fmt`를 구분후 해당하는 위치의 `str`을 날짜에 사용되는 시간으로 사용

- PR에서의 논의 결과 string format을 받아 Date함수를 리턴하는 `parseByFormat`과 `parseByFormat`을 호출하는 특수한 상황인 `parseByTimestamp` 두가지 함수를 구현했습니다.
(https://github.com/day1co/pebbles/pull/25#discussion_r740669142 에서의 논의)