### PR TITLE
feat: join과 joinTags와 join 함수를 결합 + split 함수 별도 생성(PF-8)

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -23,13 +23,33 @@ describe('StringUtil', () => {
 
   // ---------------------------------- //
 
-  describe('joinTags', () => {
-    it('should return tags in string', () => {
+  describe('split', () => {
+    it('should return array of text', () => {
+      const str = 'one, two , ,  three , four  ,five six ';
+      expect(StringUtil.split(str)).toEqual(['one', 'two', 'three', 'four', 'five six']);
+    });
+    it('should return empty array when tags are invalid', () => {
+      const str = ' , , ';
+      expect(StringUtil.split(str)).toEqual([]);
+    });
+    it('should return empty array when empty string is given', () => {
+      expect(StringUtil.split('')).toEqual([]);
+    });
+  });
+
+  // ---------------------------------- //
+
+  describe('join', () => {
+    it('should return tags in string when a list of tags is given', () => {
       const tags = [{ text: 'one' }, { text: 'two' }, { text: 'three' }, { text: 'four' }, { text: 'five six' }];
-      expect(StringUtil.joinTags(tags)).toBe('one,two,three,four,five six');
+      expect(StringUtil.join(tags)).toBe('one,two,three,four,five six');
+    });
+    it('should return string when a list of text is given', () => {
+      const textList = ['one ', ' two', ' three ', 'four', 'five six'];
+      expect(StringUtil.join(textList)).toBe('one,two,three,four,five six');
     });
     it(`should return '' when empty array is given`, () => {
-      expect(StringUtil.joinTags([])).toBe('');
+      expect(StringUtil.join([])).toBe('');
     });
   });
 

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -21,8 +21,6 @@ describe('StringUtil', () => {
     });
   });
 
-  // ---------------------------------- //
-
   describe('split', () => {
     it('should return array of text', () => {
       const str = 'one, two , ,  three , four  ,five six ';
@@ -37,23 +35,31 @@ describe('StringUtil', () => {
     });
   });
 
-  // ---------------------------------- //
+  describe('joinTags', () => {
+    it('should return string of tags', () => {
+      const tags = [{ text: 'one ' }, { text: ' two' }, { text: ' three ' }, { text: 'four' }, { text: 'five six' }];
+      expect(StringUtil.joinTags(tags)).toEqual('one,two,three,four,five six');
+    });
+    it('should return empty string when tags are invalid', () => {
+      expect(StringUtil.joinTags([{ text: ' ' }, { text: '' }])).toEqual('');
+    });
+    it('should return empty string when empty string is given', () => {
+      expect(StringUtil.joinTags([])).toEqual('');
+    });
+  });
 
   describe('join', () => {
-    it('should return tags in string when a list of tags is given', () => {
-      const tags = [{ text: 'one' }, { text: 'two' }, { text: 'three' }, { text: 'four' }, { text: 'five six' }];
-      expect(StringUtil.join(tags)).toBe('one,two,three,four,five six');
-    });
     it('should return string when a list of text is given', () => {
       const textList = ['one ', ' two', ' three ', 'four', 'five six'];
       expect(StringUtil.join(textList)).toBe('one,two,three,four,five six');
+    });
+    it('should return empty string when only empty strings are given', () => {
+      expect(StringUtil.join([' ', '  '])).toBe('');
     });
     it(`should return '' when empty array is given`, () => {
       expect(StringUtil.join([])).toBe('');
     });
   });
-
-  // ---------------------------------- //
 
   describe('compactTextMessage', () => {
     it('should allow korean text at maximum 43', () => {

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -2,23 +2,34 @@ import type { Tag } from './string-util.interface';
 
 export namespace StringUtil {
   export function splitTags(str: string, separator = ','): Tag[] {
-    const initialList: Tag[] = [];
-
-    return str.split(separator).reduce((tags, tag) => {
+    return str.split(separator).reduce((tags: Tag[], tag) => {
       const text = tag.trim();
       if (text.length > 0) {
         tags.push({ text });
       }
       return tags;
-    }, initialList);
+    }, []);
   }
 
-  export function joinTags(tags: Tag[], separator = ','): string {
-    return tags.reduce((joinedTags, tag) => {
-      if (joinedTags) {
-        joinedTags += separator;
+  export function split(str: string, separator = ','): string[] {
+    return str.split(separator).reduce((textList: string[], text) => {
+      text = text.trim();
+      if (text.length > 0) {
+        textList.push(text);
       }
-      return joinedTags + tag.text.trim();
+      return textList;
+    }, []);
+  }
+
+  export function join(textList: Array<Tag | string>, separator = ','): string {
+    return textList.reduce((joinedText: string, text) => {
+      if (joinedText) {
+        joinedText += separator;
+      }
+      if (typeof text !== 'string') {
+        return joinedText + text.text.trim();
+      }
+      return joinedText + text.trim();
     }, '');
   }
 

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -17,13 +17,17 @@ export namespace StringUtil {
     }, []);
   }
 
-  export function join(textList: Array<Tag | string>, separator = ','): string {
+  export function joinTags(tags: Tag[], separator = ','): string {
+    const textList = tags.map((tag) => {
+      return tag.text;
+    });
+    return join(textList, separator);
+  }
+
+  export function join(textList: string[], separator = ','): string {
     return textList.reduce((joinedText: string, text) => {
       if (joinedText) {
         joinedText += separator;
-      }
-      if (typeof text !== 'string') {
-        return joinedText + text.text.trim();
       }
       return joinedText + text.trim();
     }, '');

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -2,13 +2,9 @@ import type { Tag } from './string-util.interface';
 
 export namespace StringUtil {
   export function splitTags(str: string, separator = ','): Tag[] {
-    return str.split(separator).reduce((tags: Tag[], tag) => {
-      const text = tag.trim();
-      if (text.length > 0) {
-        tags.push({ text });
-      }
-      return tags;
-    }, []);
+    return split(str, separator).map((text) => {
+      return { text };
+    });
   }
 
   export function split(str: string, separator = ','): string[] {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
기존 util에 있는 `join`과 `joinTags` 함수가 코드 유사점이 많아 타입으로(array element type이 string인지, Tag타입인지) narrowing하는 `join`이라는 함수 하나로 묶었는데 이 부분에 대해서 다른분들 의견이 궁금합니다!

참고로 split과 splitTags도 유사한 점이 많았지만.. 하나로 묶기에는 분기점을 설정할만한 포인트를 못 찾아서..
생각해봤던건 parameter값에 `isReturningTags: boolean`을 넣는것이었는데 이건 뭔가 이상한 거 같아서 일단 별개의 함수로 만들어놓았습니다.

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
로컬테스트

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
