### PR TITLE
feat: string-util에 toInt, toNumber, toBoolean 함수 추가(PF-8)

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -1,6 +1,68 @@
 import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
+  describe('toInt', () => {
+    it('should return null with incompatible input', () => {
+      expect(StringUtil.toInt('abc')).toEqual(null);
+      expect(StringUtil.toInt('4.5a')).toEqual(null);
+      expect(StringUtil.toInt('1.2')).toEqual(null);
+      expect(StringUtil.toInt(1.2)).toEqual(null);
+      expect(StringUtil.toNumber('1.2.3')).toBe(null);
+      expect(StringUtil.toInt('')).toEqual(null);
+    });
+    it('should return parameter in integer type', () => {
+      expect(StringUtil.toInt(1)).toEqual(1);
+      expect(StringUtil.toInt('1')).toEqual(1);
+      expect(StringUtil.toInt(-1)).toEqual(-1);
+      expect(StringUtil.toInt('-1')).toEqual(-1);
+      expect(StringUtil.toInt(0)).toEqual(0);
+      expect(StringUtil.toInt('0')).toEqual(0);
+    });
+  });
+
+  describe('toNumber', () => {
+    it('should return null with incompatible input', () => {
+      expect(StringUtil.toNumber('abc')).toEqual(null);
+      expect(StringUtil.toNumber('4a')).toBe(null);
+      expect(StringUtil.toNumber('1.2.3')).toBe(null);
+      expect(StringUtil.toNumber(Infinity)).toBe(null);
+      expect(StringUtil.toNumber('')).toBe(null);
+    });
+    it('should return parameter in number type', () => {
+      expect(StringUtil.toNumber(1)).toEqual(1);
+      expect(StringUtil.toNumber('-1')).toEqual(-1);
+      expect(StringUtil.toNumber('0')).toEqual(0);
+      expect(StringUtil.toNumber(1.2)).toEqual(1.2);
+      expect(StringUtil.toNumber('1.2')).toEqual(1.2);
+      expect(StringUtil.toNumber(-1.2)).toEqual(-1.2);
+      expect(StringUtil.toNumber('-1.2')).toEqual(-1.2);
+    });
+  });
+
+  describe('toBoolean', () => {
+    it('should return null with incompatible input', () => {
+      expect(StringUtil.toBoolean('abc')).toEqual(null);
+      expect(StringUtil.toBoolean('1111')).toBe(null);
+      expect(StringUtil.toBoolean('')).toBe(null);
+      expect(StringUtil.toBoolean('nay')).toBe(null);
+    });
+    it('should return parameter in boolean type', () => {
+      expect(StringUtil.toBoolean(true)).toEqual(true);
+      expect(StringUtil.toBoolean('true')).toEqual(true);
+      expect(StringUtil.toBoolean(false)).toEqual(false);
+      expect(StringUtil.toBoolean('false')).toEqual(false);
+      expect(StringUtil.toBoolean('1')).toEqual(true);
+      expect(StringUtil.toBoolean('0')).toEqual(false);
+      expect(StringUtil.toBoolean('yes')).toEqual(true);
+      expect(StringUtil.toBoolean('no')).toEqual(false);
+      expect(StringUtil.toBoolean('Y')).toEqual(true);
+      expect(StringUtil.toBoolean('N')).toEqual(false);
+      expect(StringUtil.toBoolean('On')).toEqual(true);
+      expect(StringUtil.toBoolean('Off')).toEqual(false);
+      expect(StringUtil.toBoolean('TRUE')).toEqual(true);
+      expect(StringUtil.toBoolean('FALSE')).toEqual(false);
+    });
+  });
   describe('splitTags', () => {
     it('should return array of tags', () => {
       const str = 'one, two , ,  three , four  ,five six ';

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -1,44 +1,6 @@
 import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
-  describe('toInt', () => {
-    it('should return null with incompatible input', () => {
-      expect(StringUtil.toInt('abc')).toEqual(null);
-      expect(StringUtil.toInt('4.5a')).toEqual(null);
-      expect(StringUtil.toInt('1.2')).toEqual(null);
-      expect(StringUtil.toInt(1.2)).toEqual(null);
-      expect(StringUtil.toNumber('1.2.3')).toBe(null);
-      expect(StringUtil.toInt('')).toEqual(null);
-    });
-    it('should return parameter in integer type', () => {
-      expect(StringUtil.toInt(1)).toEqual(1);
-      expect(StringUtil.toInt('1')).toEqual(1);
-      expect(StringUtil.toInt(-1)).toEqual(-1);
-      expect(StringUtil.toInt('-1')).toEqual(-1);
-      expect(StringUtil.toInt(0)).toEqual(0);
-      expect(StringUtil.toInt('0')).toEqual(0);
-    });
-  });
-
-  describe('toNumber', () => {
-    it('should return null with incompatible input', () => {
-      expect(StringUtil.toNumber('abc')).toEqual(null);
-      expect(StringUtil.toNumber('4a')).toBe(null);
-      expect(StringUtil.toNumber('1.2.3')).toBe(null);
-      expect(StringUtil.toNumber(Infinity)).toBe(null);
-      expect(StringUtil.toNumber('')).toBe(null);
-    });
-    it('should return parameter in number type', () => {
-      expect(StringUtil.toNumber(1)).toEqual(1);
-      expect(StringUtil.toNumber('-1')).toEqual(-1);
-      expect(StringUtil.toNumber('0')).toEqual(0);
-      expect(StringUtil.toNumber(1.2)).toEqual(1.2);
-      expect(StringUtil.toNumber('1.2')).toEqual(1.2);
-      expect(StringUtil.toNumber(-1.2)).toEqual(-1.2);
-      expect(StringUtil.toNumber('-1.2')).toEqual(-1.2);
-    });
-  });
-
   describe('toBoolean', () => {
     it('should return null with incompatible input', () => {
       expect(StringUtil.toBoolean('abc')).toEqual(null);

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -2,11 +2,19 @@ import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
   describe('toBoolean', () => {
-    it('should return null with incompatible input', () => {
-      expect(StringUtil.toBoolean('abc')).toEqual(null);
-      expect(StringUtil.toBoolean('1111')).toBe(null);
-      expect(StringUtil.toBoolean('')).toBe(null);
-      expect(StringUtil.toBoolean('nay')).toBe(null);
+    it('should throw with incompatible input', () => {
+      expect(() => {
+        StringUtil.toBoolean('abc');
+      }).toThrow();
+      expect(() => {
+        StringUtil.toBoolean('1111');
+      }).toThrow();
+      expect(() => {
+        StringUtil.toBoolean('');
+      }).toThrow();
+      expect(() => {
+        StringUtil.toBoolean('nay');
+      }).toThrow();
     });
     it('should return parameter in boolean type', () => {
       expect(StringUtil.toBoolean(true)).toEqual(true);

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,6 +1,58 @@
 import type { Tag } from './string-util.interface';
+import { LoggerFactory } from '../logger';
+
+const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
+const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
+
+const logger = LoggerFactory.getLogger('common-util:string-util');
 
 export namespace StringUtil {
+  export function toInt(numStr: string | number): number | null {
+    let result: number | null;
+
+    if (typeof numStr === 'number') {
+      result = numStr;
+    } else {
+      result = isNumeric(numStr) ? parseFloat(numStr) : null;
+    }
+
+    if (!Number.isInteger(result)) {
+      logger.warn('incompatible parmeter with integer type "%s" caught at toInt', numStr);
+      result = null;
+    }
+    return result;
+  }
+
+  export function toNumber(numStr: string | number): number | null {
+    let result: number | null;
+
+    if (typeof numStr === 'number') {
+      result = numStr;
+    } else {
+      result = isNumeric(numStr) ? Number(numStr) : null;
+    }
+
+    if (!Number.isFinite(result)) {
+      logger.warn('incompatible parmeter with number type "%s" caught at toNumber', numStr);
+      result = null;
+    }
+    return result;
+  }
+
+  export function toBoolean(boolStr: string | boolean): boolean | null {
+    if (typeof boolStr === 'boolean') {
+      return boolStr;
+    }
+    if (TRUE_REGEXP.test(boolStr.toLowerCase())) {
+      return true;
+    }
+    if (FALSE_REGEXP.test(boolStr.toLowerCase())) {
+      return false;
+    }
+    logger.warn('incompatible parmeter with boolean type "%s" caught at toBoolean', boolStr);
+    return null;
+  }
+
   export function splitTags(str: string, separator = ','): Tag[] {
     return split(str, separator).map((text) => {
       return { text };
@@ -64,4 +116,8 @@ function substringByByteInEUCKR(str: string, byteLength: number): string {
     byte += getCharacterByteInEUCKR(str[i]);
   }
   return str.substring(0, i - 1);
+}
+
+function isNumeric(str: string): boolean {
+  return !Number.isNaN(Number(str)) && !Number.isNaN(parseInt(str));
 }

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,10 +1,7 @@
 import type { Tag } from './string-util.interface';
-import { LoggerFactory } from '../logger';
 
 const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
 const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
-
-const logger = LoggerFactory.getLogger('common-util:string-util');
 
 export namespace StringUtil {
   export function toBoolean(boolStr: string | boolean): boolean | null {
@@ -17,8 +14,7 @@ export namespace StringUtil {
     if (FALSE_REGEXP.test(boolStr.toLowerCase())) {
       return false;
     }
-    logger.warn('incompatible parmeter with boolean type "%s" caught at toBoolean', boolStr);
-    return null;
+    throw new Error(`${boolStr} is incompatible with boolean type`);
   }
 
   export function splitTags(str: string, separator = ','): Tag[] {
@@ -84,8 +80,4 @@ function substringByByteInEUCKR(str: string, byteLength: number): string {
     byte += getCharacterByteInEUCKR(str[i]);
   }
   return str.substring(0, i - 1);
-}
-
-function isNumeric(str: string): boolean {
-  return !Number.isNaN(Number(str)) && !Number.isNaN(parseInt(str));
 }

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -7,38 +7,6 @@ const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
 const logger = LoggerFactory.getLogger('common-util:string-util');
 
 export namespace StringUtil {
-  export function toInt(numStr: string | number): number | null {
-    let result: number | null;
-
-    if (typeof numStr === 'number') {
-      result = numStr;
-    } else {
-      result = isNumeric(numStr) ? parseFloat(numStr) : null;
-    }
-
-    if (!Number.isInteger(result)) {
-      logger.warn('incompatible parmeter with integer type "%s" caught at toInt', numStr);
-      result = null;
-    }
-    return result;
-  }
-
-  export function toNumber(numStr: string | number): number | null {
-    let result: number | null;
-
-    if (typeof numStr === 'number') {
-      result = numStr;
-    } else {
-      result = isNumeric(numStr) ? Number(numStr) : null;
-    }
-
-    if (!Number.isFinite(result)) {
-      logger.warn('incompatible parmeter with number type "%s" caught at toNumber', numStr);
-      result = null;
-    }
-    return result;
-  }
-
   export function toBoolean(boolStr: string | boolean): boolean | null {
     if (typeof boolStr === 'boolean') {
       return boolStr;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
[https://fastcampus.atlassian.net/jira/software/projects/PF/boards/72?selectedIssue=PF-8](https://fastcampus.atlassian.net/jira/software/projects/PF/boards/72?selectedIssue=PF-8)

## 무엇을 어떻게 변경했나요?
- redstone/util/str의 toInt, toNumber, toBoolean 추가
- 기존의 toInt나 toNumber같은 경우 '1a', '1.1ab' 와 같은 값이 들어가도 변환이 되었었는데 이를 방어하고자 isNumeric이라는 private function을 추가로 작성해 이용했습니다.

[🙋🏻‍♀️질문] int, number, boolean 타입으로 변환이 안되는 parameter가 들어왔을때, 에러를 throw해야 하는지... 로그를 남기고 null을 return해야 하는지 확신이 들지 않습니다. 
(제 생각엔) 일단 이런 상황을 에러라고 정의해야 할지 잘 모르겠고, 어디서 catch할지 모르는 throw를 하기보단 null을 반환하도록 했습니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="311" alt="Screen Shot 2021-11-01 at 7 43 40 PM" src="https://user-images.githubusercontent.com/63729090/139659781-9daa23e1-2911-4d7b-8e25-b0542cce9987.png">

