### PR TITLE
feature: StringUtil: padStart 함수

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -95,4 +95,14 @@ describe('StringUtil', () => {
       expect(trimmedText).toBe(fullText);
     });
   });
+
+  describe('padStart', () => {
+    it('padStart 의 정상 동작 확인', () => {
+      expect(StringUtil.padStart('123', 1, '0')).toBe('123');
+      expect(StringUtil.padStart('123', 2, '0')).toBe('123');
+      expect(StringUtil.padStart('123', 3, '0')).toBe('123');
+      expect(StringUtil.padStart('123', 4, '0')).toBe('0123');
+      expect(StringUtil.padStart('123', 5, '0')).toBe('00123');
+    });
+  });
 });

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -42,6 +42,14 @@ export namespace StringUtil {
     const trimmedText = substringByByteInEUCKR(textToBeTrimmed, maxByteLength - minByteLength);
     return fullText.replace(textToBeTrimmed, trimmedText + '...');
   }
+
+  export function padStart(str: string, targetLength: number, padString: string): string {
+    if (str.length >= targetLength) {
+      return str;
+    }
+
+    return new Array(targetLength - str.length + 1).join(padString) + str;
+  }
 }
 
 function getCharacterByteInEUCKR(character: string): number {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
* String.padStart는 es2017에 나온것이고 사용을 위해서는 lib 추가가 필요하다.
https://stackoverflow.com/questions/52293010/typescript-tells-me-property-padstart-does-not-exist-on-type-string-why

## 무엇을 어떻게 변경했나요?
* StringUtil에 padStart함수 생성

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
