### PR TITLE
feat: date-util - second를 받아 time 포맷으로 리턴하는 함수 추가 (PF-29)

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -284,4 +284,19 @@ describe('DateUtil', () => {
       expect(DateUtil.parseTimestamp('20210821001122123')).toEqual(new Date('2021-08-21 00:11:22.123'));
     });
   });
+
+  describe('secondsToTimeFormat', () => {
+    it('음수를 넣으면 throw가 발생한다', () => {
+      expect(() => DateUtil.secondsToTimeFormat(-5)).toThrow();
+    });
+
+    it('정상적인 값이 리턴되어야 한다', () => {
+      expect(DateUtil.secondsToTimeFormat(0)).toEqual('00:00:00');
+      expect(DateUtil.secondsToTimeFormat(10)).toEqual('00:00:10'); // 10초
+      expect(DateUtil.secondsToTimeFormat(100)).toEqual('00:01:40'); // 100초 => 1분 40초
+      expect(DateUtil.secondsToTimeFormat(1_000)).toEqual('00:16:40'); // 1,000초 => 16분 40초
+      expect(DateUtil.secondsToTimeFormat(10_000)).toEqual('02:46:40'); // 10,000초 => 2시간 46분 40초
+      expect(DateUtil.secondsToTimeFormat(100_000)).toEqual('27:46:40'); // 100,000초 => 27시간 46분 40초
+    });
+  });
 });

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -206,6 +206,21 @@ export namespace DateUtil {
   export function parseTimestamp(str: string): Date {
     return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
   }
+
+  export function secondsToTimeFormat(seconds: number): string {
+    if (seconds < 0) {
+      throw new Error('Invalid number');
+    }
+
+    const hh = Math.floor(seconds / 3600)
+      .toString()
+      .padStart(2, '0');
+    const mm = Math.floor((seconds % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const ss = (seconds % 60).toString().padStart(2, '0');
+    return `${hh}:${mm}:${ss}`;
+  }
 }
 
 function isValidDate(d: Date): boolean {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
* https://fastcampus.atlassian.net/browse/PF-29

## 무엇을 어떻게 변경했나요?
* second의 number를 받아 time 포맷 `00:00:00` 으로 리턴하는 함수 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
