### PR TITLE
feat: string-util에 validatePhoneNumber와 normalizePhoneNumber 추가

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -1,6 +1,93 @@
 import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
+  describe('normalizePhoneNumber', () => {
+    it('should normalize phone number starting with 010 or 070', () => {
+      expect(StringUtil.normalizePhoneNumber('01012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('010 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('07012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('070.1234.5678')).toBe('07012345678');
+    });
+
+    it('should normalize phone number starting with +82 or +082', () => {
+      // 010
+      expect(StringUtil.normalizePhoneNumber('+0821012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+08201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+082-10-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+082-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+082--10 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+082 010 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+8201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+821012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+82-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+82-10-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('+82 10 1234 5678')).toBe('01012345678');
+
+      // 070
+      expect(StringUtil.normalizePhoneNumber('+0827012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+08207012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+082 070 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+082-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+082 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+082-70-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+82 070 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+82-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+827012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+8207012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+82 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('+82-70-1234-5678')).toBe('07012345678');
+    });
+
+    it('should normalize phone number starting with 82 or 082', () => {
+      // 010
+      expect(StringUtil.normalizePhoneNumber('08201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('0821012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('082 10 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('082 010 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('082-10-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('082-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('821012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('8201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('82-10-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('82-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('82 10 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizePhoneNumber('82 010 1234 5678')).toBe('01012345678');
+
+      // 070
+      expect(StringUtil.normalizePhoneNumber('082 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('082-70-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('082 070 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('082-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('082 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('082-70-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('82 070 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('82-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('827012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('8207012345678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('82 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizePhoneNumber('82-70-1234-5678')).toBe('07012345678');
+    });
+
+    it('should normalize phone number even if it does not belong to domestic number type', () => {
+      expect(StringUtil.normalizePhoneNumber('+1-123-456-8900')).toBe('11234568900');
+      expect(StringUtil.normalizePhoneNumber('88123456789')).toBe('88123456789');
+      expect(StringUtil.normalizePhoneNumber('83-1234-5678')).toBe('8312345678');
+      expect(StringUtil.normalizePhoneNumber('+49 1234 56789')).toBe('49123456789');
+    });
+  });
+
+  describe('validatePhoneNumber', () => {
+    it('should validate phone number', () => {
+      expect(StringUtil.validatePhoneNumber('01012345678')).toBe(true);
+      expect(StringUtil.validatePhoneNumber('07012345678')).toBe(true);
+      expect(StringUtil.validatePhoneNumber('1012345678')).toBe(false);
+      expect(StringUtil.validatePhoneNumber('04412345678')).toBe(false);
+      expect(StringUtil.validatePhoneNumber('010123456789')).toBe(false);
+    });
+  });
+
   describe('splitTags', () => {
     it('should return array of tags', () => {
       const str = 'one, two , ,  three , four  ,five six ';

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,6 +1,26 @@
 import type { Tag } from './string-util.interface';
 
+const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
+
 export namespace StringUtil {
+  export function normalizePhoneNumber(str: string): string {
+    if (DOMESTIC_PHONE_NUMBER_REGEXP.test(str)) {
+      return str;
+    }
+
+    const NATIONAL_PHONE_NUMBER_REGEXP = /^0?820?[1,7]\d{9}$/;
+    const trimmedPhoneNumber = str.split(/\D/).join('');
+
+    if (NATIONAL_PHONE_NUMBER_REGEXP.test(trimmedPhoneNumber)) {
+      return '0' + trimmedPhoneNumber.slice(-10);
+    }
+    return trimmedPhoneNumber;
+  }
+
+  export function validatePhoneNumber(str: string): boolean {
+    return DOMESTIC_PHONE_NUMBER_REGEXP.test(str);
+  }
+
   export function splitTags(str: string, separator = ','): Tag[] {
     return split(str, separator).map((text) => {
       return { text };


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- validatePhoneNumber -> 010 XXXX XXXX이거나 070 XXXX XXXX 형식인지 검증하는 함수
- normalizePhoneNumber -> 인자값의 전화번호를 통일된 형태로 return
- redstone/util/str.js의 normalizePhoneNumber와 normalizePhone 함수를 통합하려 함

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
로컬테스트

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="311" alt="Screen Shot 2021-11-03 at 2 14 43 PM" src="https://user-images.githubusercontent.com/63729090/140012766-1f3151a3-a1d5-4dd2-9a34-dea4626a133d.png">

