### PR TITLE
feat: validateEmail 함수 추가

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -88,6 +88,50 @@ describe('StringUtil', () => {
     });
   });
 
+  describe('validateEmail', () => {
+    it('should return fail for invalid email address', () => {
+      const falseEmail_1 = '';
+      const falseEmail_2 = 'test@test';
+      const falseEmail_3 = '@test.com';
+      const falseEmail_4 = 'test@test,com';
+      const falseEmail_5 = 'test@test@test';
+      const falseEmail_6 = '.!#$%&@123123123123.com';
+      const falseEmail_7 = 'test@,!#$%&.com';
+      const falseEmail_8 = '<>@test.com';
+      const falseEmail_9 = 'test @test.com';
+      const falseEmail_10 = 'test@test.c';
+
+      expect(StringUtil.validateEmail(falseEmail_1)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_2)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_3)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_4)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_5)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_6)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_7)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_8)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_9)).toBe(false);
+      expect(StringUtil.validateEmail(falseEmail_10)).toBe(false);
+    });
+
+    it('should return true for valid email address', () => {
+      const trueEmail_1 = 'test@test.com';
+      const trueEmail_2 = 'TEST@TEST.com';
+      const trueEmail_3 = 'test.test@test.com';
+      const trueEmail_4 = 'test_##_!@test123.com';
+      const trueEmail_5 = 'test@123123123.com';
+      const trueEmail_6 = '9393933@131313.com';
+      const trueEmail_7 = '?!☺️/test/☺️!?@test.com';
+
+      expect(StringUtil.validateEmail(trueEmail_1)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_2)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_3)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_4)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_5)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_6)).toBe(true);
+      expect(StringUtil.validateEmail(trueEmail_7)).toBe(true);
+    });
+  });
+
   describe('splitTags', () => {
     it('should return array of tags', () => {
       const str = 'one, two , ,  three , four  ,five six ';

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -21,6 +21,12 @@ export namespace StringUtil {
     return DOMESTIC_PHONE_NUMBER_REGEXP.test(str);
   }
 
+  export function validateEmail(str: string): boolean {
+    const EMAIL_REGEXP =
+      /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return EMAIL_REGEXP.test(str);
+  }
+
   export function splitTags(str: string, separator = ','): Tag[] {
     return split(str, separator).map((text) => {
       return { text };


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- redstone/str의 validateEmail 이관
- 기존에 쓰던 정규표현식보다 좀 더 엄격한 룰의 정규표현식을 사용했습니다. (ex: 기존에는 test@test도 통과되었는듯 하나 통과가 안되도록)

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="309" alt="Screen Shot 2021-11-04 at 4 25 30 PM" src="https://user-images.githubusercontent.com/63729090/140273515-0b85c99c-2290-47ed-a456-b658859375cf.png">


