### PR TITLE
`toDate`를 `parse`로 이름 변경

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -1,7 +1,7 @@
 import { DateUtil } from './date-util';
 
 describe('DateUtil', () => {
-  describe('toDate', () => {
+  describe('parse', () => {
     test('invalid date input throws error', () => {
       expect(() => {
         DateUtil.parse('');

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -4,20 +4,20 @@ describe('DateUtil', () => {
   describe('toDate', () => {
     test('invalid date input throws error', () => {
       expect(() => {
-        DateUtil.toDate('');
+        DateUtil.parse('');
       }).toThrow();
       expect(() => {
-        DateUtil.toDate('abc');
+        DateUtil.parse('abc');
       }).toThrow();
       expect(() => {
-        DateUtil.toDate('3월 9일');
+        DateUtil.parse('3월 9일');
       }).toThrow();
     });
     test('valid date input returns instance of Date', () => {
       const testDate = new Date();
-      expect(DateUtil.toDate(testDate).getTime()).toEqual(testDate.getTime());
-      expect(DateUtil.toDate('2021-01-01T01:01:01Z').getTime()).toBe(new Date('2021-01-01T01:01:01Z').getTime());
-      expect(DateUtil.toDate('2021-10-10').getTime()).toEqual(new Date('2021-10-10').getTime());
+      expect(DateUtil.parse(testDate).getTime()).toEqual(testDate.getTime());
+      expect(DateUtil.parse('2021-01-01T01:01:01Z').getTime()).toBe(new Date('2021-01-01T01:01:01Z').getTime());
+      expect(DateUtil.parse('2021-10-10').getTime()).toEqual(new Date('2021-10-10').getTime());
     });
   });
 

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -10,7 +10,7 @@ const ONE_MINUTE_IN_SECOND = 60;
 const logger = LoggerFactory.getLogger('common-util:date-util');
 
 export namespace DateUtil {
-  export function toDate(d: DateType): Date {
+  export function parse(d: DateType): Date {
     const originalD = d;
     if (!(d instanceof Date)) {
       d = new Date(d);
@@ -25,7 +25,7 @@ export namespace DateUtil {
 
   export function calcDatetime(d: DateType, opts: CalcDatetimeOpts): Date {
     try {
-      const date = toDate(d);
+      const date = parse(d);
 
       if (opts.year) {
         date.setFullYear(date.getFullYear() + opts.year);
@@ -59,23 +59,23 @@ export namespace DateUtil {
   }
 
   export function beginOfMonth(date: DateType = new Date()): Date {
-    date = toDate(date);
+    date = parse(date);
     return new Date(date.getFullYear(), date.getMonth(), 1);
   }
 
   export function endOfMonth(date: DateType = new Date()): Date {
-    date = toDate(date);
+    date = parse(date);
     return new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
   }
 
   export function lastDayOfMonth(date: DateType = new Date()): Date {
-    date = toDate(date);
+    date = parse(date);
     return new Date(date.getFullYear(), date.getMonth() + 1, 0);
   }
 
   export function diff(since: DateType, until: DateType, type: DatePropertyType): number {
-    const sinceDate = toDate(since);
-    const untilDate = toDate(until);
+    const sinceDate = parse(since);
+    const untilDate = parse(until);
 
     if (untilDate < sinceDate) {
       return -diff(until, since, type);
@@ -112,10 +112,10 @@ export namespace DateUtil {
   }
 
   export function minDate(first: DateType, ...rest: DateType[]): Date {
-    let min = toDate(first);
+    let min = parse(first);
 
     for (let item of rest) {
-      item = toDate(item);
+      item = parse(item);
       min = item < min ? item : min;
     }
     return min;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
`toDate`를 `parse`로 이름 변경하여 `new Date()` 로 대응가능한 변수들을 처리하도록 했습니다.

참고: redstone에 있던, string format를 받아 Date로 처리하는 `parse` 메서드는 `parseByFormat`으로 구현되어, PR머지 되었습니다. https://github.com/day1co/pebbles/pull/25

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
