### PR TITLE
feat: string-util에 getNonce 함수 추가(PF-8)

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -1,6 +1,31 @@
 import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
+  describe('getNonce', () => {
+    it('should return a random string', () => {
+      const nonce1 = StringUtil.getNonce(8, 16);
+      const nonce2 = StringUtil.getNonce(8, 16);
+      const nonce3 = StringUtil.getNonce(8, 16);
+      const nonce4 = StringUtil.getNonce(10, 36);
+      const nonce5 = StringUtil.getNonce(10, 36);
+      const nonce6 = StringUtil.getNonce(10, 36);
+
+      expect(nonce1).toHaveLength(8);
+      expect(nonce2).toHaveLength(8);
+      expect(nonce3).toHaveLength(8);
+      expect(nonce4).toHaveLength(10);
+      expect(nonce5).toHaveLength(10);
+      expect(nonce6).toHaveLength(10);
+
+      expect(nonce1).not.toEqual(nonce2);
+      expect(nonce1).not.toEqual(nonce3);
+      expect(nonce2).not.toEqual(nonce3);
+      expect(nonce4).not.toEqual(nonce5);
+      expect(nonce4).not.toEqual(nonce6);
+      expect(nonce5).not.toEqual(nonce6);
+    });
+  });
+
   describe('normalizePhoneNumber', () => {
     it('should normalize phone number starting with 010 or 070', () => {
       expect(StringUtil.normalizePhoneNumber('01012345678')).toBe('01012345678');

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -4,9 +4,9 @@ const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
 
 export namespace StringUtil {
   export function getNonce(nonceLength: number, nonceEncoding: number): string {
-    const substringStartAt = -Math.abs(nonceLength);
-    return Math.random().toString(nonceEncoding).substr(substringStartAt);
+    return Math.random().toString(nonceEncoding).substr(-nonceLength);
   }
+
   export function normalizePhoneNumber(str: string): string {
     if (DOMESTIC_PHONE_NUMBER_REGEXP.test(str)) {
       return str;

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -3,6 +3,10 @@ import type { Tag } from './string-util.interface';
 const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
 
 export namespace StringUtil {
+  export function getNonce(nonceLength: number, nonceEncoding: number): string {
+    const substringStartAt = -Math.abs(nonceLength);
+    return Math.random().toString(nonceEncoding).substr(substringStartAt);
+  }
   export function normalizePhoneNumber(str: string): string {
     if (DOMESTIC_PHONE_NUMBER_REGEXP.test(str)) {
       return str;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
nonce 생성함수가 redstone/util에 있음에도 다른 코드들이 util로부터 import하지 않고 각자 함수 생성해서 사용중

## 무엇을 어떻게 변경했나요?
redstone/util의 nonce 함수를 getNonce로 바꾸고 toString의 인코딩 인자값을 받을 수 있도록 수정

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="311" alt="Screen Shot 2021-11-08 at 1 35 32 PM" src="https://user-images.githubusercontent.com/63729090/140684948-f6aebb2a-fe42-4027-94f7-dd87471de757.png">

