### PR TITLE
feat: date-util에 format 추가

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -285,6 +285,32 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('format', () => {
+    it('should throw with invalid format string', () => {
+      expect(() => DateUtil.format(new Date(), 'y년 m월 d일')).toThrow();
+      expect(() => DateUtil.format(new Date(), 'yyyy-mm-dd')).toThrow();
+      expect(() => DateUtil.format(new Date(), 'YYYY-MM-DD h')).toThrow();
+      expect(() => DateUtil.format(new Date(), 'YYYY년 MM월 d일')).toThrow();
+    });
+    it('should format date to string with specific format rule', () => {
+      const testDate1 = new Date('2020-01-01 01:01:01:111');
+      expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-01-01 01:01:01');
+      expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-01-01 01:01:01.111');
+      expect(DateUtil.format(testDate1, 'YYYY년 MM월 DD일')).toEqual('2020년 01월 01일');
+      expect(DateUtil.format(testDate1, 'YYYY년 M월 D일 H시 m분 s초')).toEqual('2020년 1월 1일 1시 1분 1초');
+      expect(DateUtil.format(testDate1, 'M/D')).toEqual('1/1');
+      expect(DateUtil.format(testDate1, 'MM월 DD일')).toEqual('01월 01일');
+
+      const testDate2 = new Date('2020-11-11 23:23:23:999');
+      expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-11-11 23:23:23');
+      expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-11-11 23:23:23.999');
+      expect(DateUtil.format(testDate2, 'YYYY년 MM월 DD일')).toEqual('2020년 11월 11일');
+      expect(DateUtil.format(testDate2, 'YYYY년 M월 D일 H시 m분 s초')).toEqual('2020년 11월 11일 23시 23분 23초');
+      expect(DateUtil.format(testDate2, 'M/D')).toEqual('11/11');
+      expect(DateUtil.format(testDate2, 'MM월 DD일')).toEqual('11월 11일');
+    });
+  });
+
   describe('secondsToTimeFormat', () => {
     it('음수를 넣으면 throw가 발생한다', () => {
       expect(() => DateUtil.secondsToTimeFormat(-5)).toThrow();

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -207,6 +207,68 @@ export namespace DateUtil {
     return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
   }
 
+  export function format(d: Date, format: string): string {
+    const year = d.getFullYear();
+    const month = d.getMonth() + 1;
+    const day = d.getDate();
+    const hour = d.getHours();
+    const minute = d.getMinutes();
+    const second = d.getSeconds();
+    const millisecond = d.getMilliseconds();
+
+    const FORMAT_RULE_REGEXP = /[yYmMdDhHsS]{1,4}/g;
+
+    const formattedDate = format.replace(FORMAT_RULE_REGEXP, (match) => {
+      switch (match) {
+        case 'YYYY':
+          return `${year}`;
+        case 'YY':
+          return `${year % 100}`;
+
+        case 'MM':
+          return `${month}`.padStart(2, '0');
+        case 'M':
+          return `${month}`;
+
+        case 'DD':
+          return `${day}`.padStart(2, '0');
+        case 'D':
+          return `${day}`;
+
+        case 'HH':
+          return `${hour}`.padStart(2, '0');
+        case 'H':
+          return `${hour}`;
+
+        case 'mm':
+          return `${minute}`.padStart(2, '0');
+        case 'm':
+          return `${minute}`;
+
+        case 'ss':
+          return `${second}`.padStart(2, '0');
+        case 's':
+          return `${second}`;
+
+        case 'SSS':
+          return `${millisecond}`.padStart(3, '0');
+        case 'SS':
+          return `${millisecond}`.padStart(2, '0');
+        case 'S':
+          return `${millisecond}`;
+
+        default:
+          return match;
+      }
+    });
+
+    if (FORMAT_RULE_REGEXP.test(formattedDate)) {
+      throw new Error(`Invalid format: ${formattedDate}`);
+    }
+
+    return formattedDate;
+  }
+
   export function secondsToTimeFormat(seconds: number): string {
     if (seconds < 0) {
       throw new Error('Invalid number');


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- date를 특정 format 형식의 string으로 반환하는 함수 추가
- 기존 util/str.js 에도 formatDateToString이란 함수가 있던데 date-util의 format과 통합하고자 합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="297" alt="Screen Shot 2021-11-08 at 4 47 39 PM" src="https://user-images.githubusercontent.com/63729090/140703167-59e9f27d-5b95-47d8-b181-07b4151bc97b.png">


