### PR TITLE
misc: pacakge.json - 빌드와 배포는 별도로 실행되어야 함

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf ./dist ./node_modules",
     "lint": "eslint .",
     "prebuild": "npm run lint",
-    "prepublishOnly": "npm run build",
+    "postbuild": "cp package.json dist",
     "test": "jest --detectOpenHandles --forceExit ./src"
   },
   "type": "module",


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
* npm publish할 때 prepublishOnly 에 의해 npm run build가 실행되고 있음
(배포할 때 package.json이 필요하고, 배포하는 대상이 dist폴더이기 때문에 dist에 package.json을 복사하는 과정이 필요합니다)

## 무엇을 어떻게 변경했나요?
* prepublishOnly를 제거하고 postbuild에 package.json을 dist로 복사하도록 수정

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
* npm publish의 lifecycle -> https://docs.npmjs.com/cli/v8/using-npm/scripts#npm-publish
* 배포 액션 (github publish action)에서는 
`npm run build && cd dist && npm publish`와 같은 스크립트로 작성할 예정입니다.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
pebbles-test 패키지를 임의로 만들어서 테스트
https://github.com/day1co/pebbles/packages/1100340

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요
<img width="438" alt="스크린샷 2021-11-17 오후 3 43 24" src="https://user-images.githubusercontent.com/39257313/142148081-cac39253-72b6-478a-9d18-1be95d976a87.png">

npm 패키지 설치 시 이와같은 폴더구조로 설치됨