### PR TITLE
feat: date-util format의 기본 return값을 utc로 수정

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -292,8 +292,9 @@ describe('DateUtil', () => {
       expect(() => DateUtil.format(new Date(), 'YYYY-MM-DD h')).toThrow();
       expect(() => DateUtil.format(new Date(), 'YYYY년 MM월 d일')).toThrow();
     });
-    it('should format date to string with specific format rule', () => {
-      const testDate1 = new Date('2020-01-01 01:01:01:111');
+
+    it('should format date to UTC string with specific format rule', () => {
+      const testDate1 = new Date('2020-01-01 01:01:01:111Z');
       expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-01-01 01:01:01');
       expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-01-01 01:01:01.111');
       expect(DateUtil.format(testDate1, 'YYYY년 MM월 DD일')).toEqual('2020년 01월 01일');
@@ -301,7 +302,7 @@ describe('DateUtil', () => {
       expect(DateUtil.format(testDate1, 'M/D')).toEqual('1/1');
       expect(DateUtil.format(testDate1, 'MM월 DD일')).toEqual('01월 01일');
 
-      const testDate2 = new Date('2020-11-11 23:23:23:999');
+      const testDate2 = new Date('2020-11-11 23:23:23:999Z');
       expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-11-11 23:23:23');
       expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-11-11 23:23:23.999');
       expect(DateUtil.format(testDate2, 'YYYY년 MM월 DD일')).toEqual('2020년 11월 11일');
@@ -309,16 +310,42 @@ describe('DateUtil', () => {
       expect(DateUtil.format(testDate2, 'M/D')).toEqual('11/11');
       expect(DateUtil.format(testDate2, 'MM월 DD일')).toEqual('11월 11일');
     });
+
+    it('should format local date to UTC string', () => {
+      const testDate1 = new Date('2020-01-01 00:00:00:000+06:00');
+      expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss')).toEqual('2019-12-31 18:00:00');
+
+      const testDate2 = new Date('2020-01-01 09:00:00:000+09:00');
+      expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-01-01 00:00:00');
+
+      const testDate3 = new Date('2020-11-30 20:00:00:000-10:00');
+      expect(DateUtil.format(testDate3, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-12-01 06:00:00');
+    });
+  });
+
+  describe('formatInLocalTimeZone', () => {
+    it('', () => {
+      const testDate1 = new Date('2020-01-01 00:00:00:000+06:00');
+      const localHour1 = testDate1.getHours();
+      const localMinute1 = testDate1.getMinutes();
+
+      expect(DateUtil.formatInLocalTimeZone(testDate1, 'H:m')).toEqual(`${localHour1}:${localMinute1}`);
+
+      const testDate2 = new Date('2020-01-01 09:00:00:000+09:00');
+      const localHour2 = testDate2.getHours();
+      const localMinute2 = testDate2.getMinutes();
+      expect(DateUtil.formatInLocalTimeZone(testDate2, 'H:m')).toEqual(`${localHour2}:${localMinute2}`);
+    });
   });
 
   describe('formatToISOString', () => {
     it('should return date to ISO format string', () => {
-      const testDate1 = new Date('2020-01-01 01:01:01:111');
+      const testDate1 = new Date('2020-01-01 01:01:01:111Z');
       expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DD')).toEqual('2020-01-01');
       expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DDTHH:mm:ss.SSS')).toEqual('2020-01-01T01:01:01.111');
       expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DDTHH:mm:ss')).toEqual('2020-01-01T01:01:01');
 
-      const testDate2 = new Date('2020-11-11 23:23:23:999');
+      const testDate2 = new Date('2020-11-11 23:23:23:999Z');
       expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DD')).toEqual('2020-11-11');
       expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DDTHH:mm:ss.SSS')).toEqual('2020-11-11T23:23:23.999');
       expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DDTHH:mm:ss')).toEqual('2020-11-11T23:23:23');

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -208,6 +208,18 @@ export namespace DateUtil {
   }
 
   export function format(d: Date, format: string): string {
+    const year = d.getUTCFullYear();
+    const month = d.getUTCMonth() + 1;
+    const day = d.getUTCDate();
+    const hour = d.getUTCHours();
+    const minute = d.getUTCMinutes();
+    const second = d.getUTCSeconds();
+    const millisecond = d.getUTCMilliseconds();
+
+    return replaceFormatWithRegExp(format, year, month, day, hour, minute, second, millisecond);
+  }
+
+  export function formatInLocalTimeZone(d: Date, format: string): string {
     const year = d.getFullYear();
     const month = d.getMonth() + 1;
     const day = d.getDate();
@@ -216,57 +228,7 @@ export namespace DateUtil {
     const second = d.getSeconds();
     const millisecond = d.getMilliseconds();
 
-    const FORMAT_RULE_REGEXP = /[yYmMdDhHsS]{1,4}/g;
-
-    const formattedDate = format.replace(FORMAT_RULE_REGEXP, (match) => {
-      switch (match) {
-        case 'YYYY':
-          return `${year}`;
-        case 'YY':
-          return `${year % 100}`;
-
-        case 'MM':
-          return `${month}`.padStart(2, '0');
-        case 'M':
-          return `${month}`;
-
-        case 'DD':
-          return `${day}`.padStart(2, '0');
-        case 'D':
-          return `${day}`;
-
-        case 'HH':
-          return `${hour}`.padStart(2, '0');
-        case 'H':
-          return `${hour}`;
-
-        case 'mm':
-          return `${minute}`.padStart(2, '0');
-        case 'm':
-          return `${minute}`;
-
-        case 'ss':
-          return `${second}`.padStart(2, '0');
-        case 's':
-          return `${second}`;
-
-        case 'SSS':
-          return `${millisecond}`.padStart(3, '0');
-        case 'SS':
-          return `${millisecond}`.padStart(2, '0');
-        case 'S':
-          return `${millisecond}`;
-
-        default:
-          return match;
-      }
-    });
-
-    if (FORMAT_RULE_REGEXP.test(formattedDate)) {
-      throw new Error(`Invalid format: ${formattedDate}`);
-    }
-
-    return formattedDate;
+    return replaceFormatWithRegExp(format, year, month, day, hour, minute, second, millisecond);
   }
 
   export function formatToISOString(d: Date, ISOFormat: ISO8601FormatType): string {
@@ -309,4 +271,67 @@ function diffMonth(since: Date, until: Date): number {
   }
 
   return diffMonth;
+}
+
+function replaceFormatWithRegExp(
+  format: string,
+  year?: number,
+  month?: number,
+  day?: number,
+  hour?: number,
+  minute?: number,
+  second?: number,
+  millisecond?: number
+): string {
+  const FORMAT_RULE_REGEXP = /[yYmMdDhHsS]{1,4}/g;
+
+  const formattedDate = format.replace(FORMAT_RULE_REGEXP, (match) => {
+    switch (match) {
+      case 'YYYY':
+        return `${year}`;
+      case 'YY':
+        return `${year}`.padStart(2, '0');
+
+      case 'MM':
+        return `${month}`.padStart(2, '0');
+      case 'M':
+        return `${month}`;
+
+      case 'DD':
+        return `${day}`.padStart(2, '0');
+      case 'D':
+        return `${day}`;
+
+      case 'HH':
+        return `${hour}`.padStart(2, '0');
+      case 'H':
+        return `${hour}`;
+
+      case 'mm':
+        return `${minute}`.padStart(2, '0');
+      case 'm':
+        return `${minute}`;
+
+      case 'ss':
+        return `${second}`.padStart(2, '0');
+      case 's':
+        return `${second}`;
+
+      case 'SSS':
+        return `${millisecond}`.padStart(3, '0');
+      case 'SS':
+        return `${millisecond}`.padStart(2, '0');
+      case 'S':
+        return `${millisecond}`;
+
+      default:
+        return match;
+    }
+  });
+
+  if (FORMAT_RULE_REGEXP.test(formattedDate)) {
+    throw new Error(`Invalid format: ${formattedDate}`);
+  }
+
+  return formattedDate;
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
- 기존의 format 방식이 `d.getFullYears()`와 같은 메서드를 사용했었는데, 이게 런타임의 local timezone에 따른 날짜 string이 반환되는 문제가 있었습니다.
- UTC 타임을 format해도 local timezone에 따른 결과값이 나오게 됩니다. 
- (ex: `2000-10-10 10:00:00Z` 이란 날짜가 있다고 가정했을 때 format의 결과값은 `2020-10-10 19:00:00` 가 출력 ) 

## 무엇을 어떻게 변경했나요?
- `format`이 기본적으로 utc를 기준으로 하도록 변경했습니다. ex: `d.getFullYears() -> d.getUTCFullYears()`
- 기존 `format`은 `formatInLocalTimeZone`으로 명칭을 바꾸었습니다.
- `format`과 `formatInLocalTimeZone`에 공통으로 쓰일 정규표현식 함수는 private function으로 분리했습니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
- 테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
