### PR TITLE
misc: npm publish하기 전에 npm run build가 자동으로 되는 과정 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "clean": "rimraf ./dist ./node_modules",
     "lint": "eslint .",
     "prebuild": "npm run lint",
-    "prepublishOnly": "npm run build",
     "test": "jest --detectOpenHandles --forceExit ./src"
   },
   "type": "module",


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
1. ts에서는 tsc의 결과물인 dist폴더를 배포되어야 함
2. publish에서는 node_modules가 설치되어있지 않아도 실행되어야 하는데 npm run build로 인해 npm i 과정이 필요해짐
3. dist안에는 node_modules 폴더가 없음

## 무엇을 어떻게 변경했나요?
* npm run build와 npm publish를 분리
(npm publish를 실행했을 때 npm run build가 자동으로 실행되는 코드 제거 - prepublishOnly)
* #42 에서 수정한 내용에서 cp 과정을 npm run build에 넣지 않고, publish하는 github action에서 하는게 더 맞을 듯 하여 다시 올립니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
* npm publish의 lifecycle -> docs.npmjs.com/cli/v8/using-npm/scripts#npm-publish
* docs.npmjs.com/cli/v8/commands/npm-publish (publish하는 폴더에는 package.json이 있어야 함)
(: A folder containing a package.json file)

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
