### PR TITLE
feat: setUTCOffset(구 utcOffset) 추가 및 format 수정

### DIFF
--- a/src/date-util/date-util.interface.ts
+++ b/src/date-util/date-util.interface.ts
@@ -7,12 +7,7 @@ export interface CalcDatetimeOpts {
   readonly second?: number;
 }
 
-export interface DateInfo {
-  year: number;
-  month: number;
-  date: number;
-  hour: number;
-  minute: number;
-  second: number;
-  millisecond: number;
+export interface DateFormatOpts {
+  readonly format?: string;
+  readonly isUTC?: boolean;
 }

--- a/src/date-util/date-util.interface.ts
+++ b/src/date-util/date-util.interface.ts
@@ -6,3 +6,13 @@ export interface CalcDatetimeOpts {
   readonly minute?: number;
   readonly second?: number;
 }
+
+export interface DateInfo {
+  year: number;
+  month: number;
+  date: number;
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+}

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -305,11 +305,11 @@ describe('DateUtil', () => {
 
     it('should format return value of setUTCOffset() according to its UTC offset', () => {
       const testDate1 = DateUtil.setUTCOffset(new Date('2000-01-01T00:00:00Z'), 540);
-      expect(DateUtil.format(testDate1, 'YYYY-MM-DDTHH:mm:ss')).toBe('2000-01-01T09:00:00');
+      expect(DateUtil.format(testDate1)).toBe('2000-01-01T09:00:00+09:00');
       expect(DateUtil.format(testDate1, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
 
       const testDate2 = DateUtil.setUTCOffset(new Date('2000-01-01T09:00:00+09:00'), 540);
-      expect(DateUtil.format(testDate2, 'YYYY-MM-DDTHH:mm:ss')).toBe('2000-01-01T09:00:00');
+      expect(DateUtil.format(testDate2)).toBe('2000-01-01T09:00:00+09:00');
       expect(DateUtil.format(testDate2, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
     });
   });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -269,6 +269,14 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('setUTCOffset', () => {
+    it('should return date with UTCOffsetMin', () => {
+      const testDate1 = new Date('2020-01-01T01:01:01Z');
+      expect(DateUtil.setUTCOffset(testDate1, 180)).toHaveProperty('UTCOffsetMin');
+      expect(DateUtil.setUTCOffset(testDate1, 180)).toBeInstanceOf(Date);
+    });
+  });
+
   describe('format', () => {
     it('should throw with invalid format string', () => {
       expect(() => DateUtil.format(new Date(), 'y년 m월 d일')).toThrow();
@@ -276,6 +284,7 @@ describe('DateUtil', () => {
       expect(() => DateUtil.format(new Date(), 'YYYY-MM-DD h')).toThrow();
       expect(() => DateUtil.format(new Date(), 'YYYY년 MM월 d일')).toThrow();
     });
+
     it('should format date to string with specific format rule', () => {
       const testDate1 = new Date('2020-01-01 01:01:01:111');
       expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-01-01 01:01:01');
@@ -292,6 +301,16 @@ describe('DateUtil', () => {
       expect(DateUtil.format(testDate2, 'YYYY년 M월 D일 H시 m분 s초')).toEqual('2020년 11월 11일 23시 23분 23초');
       expect(DateUtil.format(testDate2, 'M/D')).toEqual('11/11');
       expect(DateUtil.format(testDate2, 'MM월 DD일')).toEqual('11월 11일');
+    });
+
+    it('should format return value of setUTCOffset() according to its UTC offset', () => {
+      const testDate1 = DateUtil.setUTCOffset(new Date('2000-01-01T00:00:00Z'), 540);
+      expect(DateUtil.format(testDate1, 'YYYY-MM-DDTHH:mm:ss')).toBe('2000-01-01T09:00:00');
+      expect(DateUtil.format(testDate1, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
+
+      const testDate2 = DateUtil.setUTCOffset(new Date('2000-01-01T09:00:00+09:00'), 540);
+      expect(DateUtil.format(testDate2, 'YYYY-MM-DDTHH:mm:ss')).toBe('2000-01-01T09:00:00');
+      expect(DateUtil.format(testDate2, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
     });
   });
 

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -270,65 +270,106 @@ describe('DateUtil', () => {
   });
 
   describe('setUTCOffset', () => {
-    it('should return date with UTCOffsetMinute', () => {
-      const testDate1 = new Date('2020-01-01T01:01:01Z');
-      expect(DateUtil.setUTCOffset(testDate1, 180)).toHaveProperty('UTCOffsetMinute');
-      expect(DateUtil.setUTCOffset(testDate1, 180)).toBeInstanceOf(Date);
+    const testDate1 = '2020-01-01 01:01:01Z';
+    const testDate2 = '2020-01-01 00:00:00-09:00';
+    const testDate3 = '2020-01-01 00:00:00+09:00';
+
+    it('should set given date`s utc time by given offset', () => {
+      expect(DateUtil.setUTCOffset(new Date(testDate1), 180)).toEqual(new Date('2020-01-01 04:01:01Z'));
+      expect(DateUtil.setUTCOffset(new Date(testDate2), 180)).toEqual(new Date('2020-01-01 12:00:00Z'));
+      expect(DateUtil.setUTCOffset(new Date(testDate3), 540)).toEqual(new Date('2020-01-01 00:00:00Z'));
+    });
+
+    it('should parse string to date and set it`s utc time by given offset', () => {
+      expect(DateUtil.setUTCOffset(testDate1, 180)).toEqual(new Date('2020-01-01 04:01:01Z'));
+      expect(DateUtil.setUTCOffset(testDate2, 180)).toEqual(new Date('2020-01-01 12:00:00Z'));
+      expect(DateUtil.setUTCOffset(testDate3, 540)).toEqual(new Date('2020-01-01 00:00:00Z'));
     });
   });
 
   describe('format', () => {
     it('should throw with invalid format string', () => {
-      expect(() => DateUtil.format(new Date(), 'y년 m월 d일')).toThrow();
-      expect(() => DateUtil.format(new Date(), 'yyyy-mm-dd')).toThrow();
-      expect(() => DateUtil.format(new Date(), 'YYYY-MM-DD h')).toThrow();
-      expect(() => DateUtil.format(new Date(), 'YYYY년 MM월 d일')).toThrow();
+      expect(() => DateUtil.format(new Date(), { format: 'y년 m월 d일' })).toThrow();
+      expect(() => DateUtil.format(new Date(), { format: 'yyyy-mm-dd' })).toThrow();
+      expect(() => DateUtil.format(new Date(), { format: 'YYYY-MM-DD h' })).toThrow();
+      expect(() => DateUtil.format(new Date(), { format: 'YYYY년 MM월 d일' })).toThrow();
     });
 
     it('should format date to string with specific format rule', () => {
       const testDate1 = new Date('2020-01-01 01:01:01:111');
-      expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-01-01 01:01:01');
-      expect(DateUtil.format(testDate1, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-01-01 01:01:01.111');
-      expect(DateUtil.format(testDate1, 'YYYY년 MM월 DD일')).toEqual('2020년 01월 01일');
-      expect(DateUtil.format(testDate1, 'YYYY년 M월 D일 H시 m분 s초')).toEqual('2020년 1월 1일 1시 1분 1초');
-      expect(DateUtil.format(testDate1, 'M/D')).toEqual('1/1');
-      expect(DateUtil.format(testDate1, 'MM월 DD일')).toEqual('01월 01일');
+      expect(DateUtil.format(testDate1, { format: 'YYYY-MM-DD HH:mm:ss' })).toEqual('2020-01-01 01:01:01');
+      expect(DateUtil.format(testDate1, { format: 'YYYY-MM-DD HH:mm:ss.SSS' })).toEqual('2020-01-01 01:01:01.111');
+      expect(DateUtil.format(testDate1, { format: 'YYYY년 MM월 DD일' })).toEqual('2020년 01월 01일');
+      expect(DateUtil.format(testDate1, { format: 'YYYY년 M월 D일 H시 m분 s초' })).toEqual(
+        '2020년 1월 1일 1시 1분 1초'
+      );
+      expect(DateUtil.format(testDate1, { format: 'M/D' })).toEqual('1/1');
+      expect(DateUtil.format(testDate1, { format: 'MM월 DD일' })).toEqual('01월 01일');
 
       const testDate2 = new Date('2020-11-11 23:23:23:999');
-      expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss')).toEqual('2020-11-11 23:23:23');
-      expect(DateUtil.format(testDate2, 'YYYY-MM-DD HH:mm:ss.SSS')).toEqual('2020-11-11 23:23:23.999');
-      expect(DateUtil.format(testDate2, 'YYYY년 MM월 DD일')).toEqual('2020년 11월 11일');
-      expect(DateUtil.format(testDate2, 'YYYY년 M월 D일 H시 m분 s초')).toEqual('2020년 11월 11일 23시 23분 23초');
-      expect(DateUtil.format(testDate2, 'M/D')).toEqual('11/11');
-      expect(DateUtil.format(testDate2, 'MM월 DD일')).toEqual('11월 11일');
+      expect(DateUtil.format(testDate2, { format: 'YYYY-MM-DD HH:mm:ss' })).toEqual('2020-11-11 23:23:23');
+      expect(DateUtil.format(testDate2, { format: 'YYYY-MM-DD HH:mm:ss.SSS' })).toEqual('2020-11-11 23:23:23.999');
+      expect(DateUtil.format(testDate2, { format: 'YYYY년 MM월 DD일' })).toEqual('2020년 11월 11일');
+      expect(DateUtil.format(testDate2, { format: 'YYYY년 M월 D일 H시 m분 s초' })).toEqual(
+        '2020년 11월 11일 23시 23분 23초'
+      );
+      expect(DateUtil.format(testDate2, { format: 'M/D' })).toEqual('11/11');
+      expect(DateUtil.format(testDate2, { format: 'MM월 DD일' })).toEqual('11월 11일');
     });
 
-    it('should format return value of setUTCOffset() according to its UTC offset', () => {
-      const testDate1 = DateUtil.setUTCOffset(new Date('2000-01-01T00:00:00Z'), 540);
-      expect(DateUtil.format(testDate1)).toBe('2000-01-01T09:00:00+09:00');
-      expect(DateUtil.format(testDate1, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
+    it('should format date to string with default format rule', () => {
+      const defaultFormat = 'YYYY-MM-DDTHH:mm:ss±00:00';
+      const utcOffsetHourIdx = defaultFormat.indexOf('±') + 1;
 
-      const testDate2 = DateUtil.setUTCOffset(new Date('2000-01-01T09:00:00+09:00'), 540);
-      expect(DateUtil.format(testDate2)).toBe('2000-01-01T09:00:00+09:00');
-      expect(DateUtil.format(testDate2, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
+      const localTimezoneOffset = -new Date().getTimezoneOffset();
+      const localTimezoneHoursStr = String(Math.floor(localTimezoneOffset / 60));
 
-      const testDate3 = DateUtil.setUTCOffset(new Date('2000-01-01T00:00:00Z'), -300);
-      expect(DateUtil.format(testDate3)).toBe('1999-12-31T19:00:00-05:00');
-      expect(DateUtil.format(testDate3, 'M월 D일 H시 m분')).toBe('12월 31일 19시 0분');
+      const testDate1 = new Date('2000-01-01T00:00:00Z');
+      const testDate2 = new Date('2000-01-01T09:00:00+09:00');
+      const testDate3 = new Date('2000-01-01T00:00:00');
+
+      expect(DateUtil.format(testDate1).length).toBe(defaultFormat.length);
+      expect(DateUtil.format(testDate1).slice(utcOffsetHourIdx, utcOffsetHourIdx + 2)).toBe(
+        localTimezoneHoursStr.padStart(2, '0')
+      );
+
+      expect(DateUtil.format(testDate2).length).toBe(defaultFormat.length);
+      expect(DateUtil.format(testDate2).slice(utcOffsetHourIdx, utcOffsetHourIdx + 2)).toBe(
+        localTimezoneHoursStr.padStart(2, '0')
+      );
+
+      expect(DateUtil.format(testDate3).length).toBe(defaultFormat.length);
+      expect(DateUtil.format(testDate3).slice(utcOffsetHourIdx, utcOffsetHourIdx + 2)).toBe(
+        localTimezoneHoursStr.padStart(2, '0')
+      );
+    });
+
+    it('should format date to string in UTC if isUTC option is true', () => {
+      const testDate1 = new Date('2000-01-01 00:00:00.999Z');
+      const testDate2 = new Date('2000-01-01 00:00:00-03:00');
+      const testDate3 = new Date('2000-01-01 00:00:00+09:00');
+
+      expect(DateUtil.format(testDate1, { isUTC: true })).toBe('2000-01-01T00:00:00Z');
+      expect(DateUtil.format(testDate2, { isUTC: true })).toBe('2000-01-01T03:00:00Z');
+      expect(DateUtil.format(testDate3, { isUTC: true })).toBe('1999-12-31T15:00:00Z');
     });
   });
 
   describe('formatToISOString', () => {
     it('should return date to ISO format string', () => {
       const testDate1 = new Date('2020-01-01 01:01:01:111');
-      expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DD')).toEqual('2020-01-01');
-      expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DDTHH:mm:ss.SSS')).toEqual('2020-01-01T01:01:01.111');
-      expect(DateUtil.formatToISOString(testDate1, 'YYYY-MM-DDTHH:mm:ss')).toEqual('2020-01-01T01:01:01');
+      expect(DateUtil.formatToISOString(testDate1, { format: 'YYYY-MM-DD' })).toEqual('2020-01-01');
+      expect(DateUtil.formatToISOString(testDate1, { format: 'YYYY-MM-DDTHH:mm:ss.SSS' })).toEqual(
+        '2020-01-01T01:01:01.111'
+      );
+      expect(DateUtil.formatToISOString(testDate1, { format: 'YYYY-MM-DDTHH:mm:ss' })).toEqual('2020-01-01T01:01:01');
 
       const testDate2 = new Date('2020-11-11 23:23:23:999');
-      expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DD')).toEqual('2020-11-11');
-      expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DDTHH:mm:ss.SSS')).toEqual('2020-11-11T23:23:23.999');
-      expect(DateUtil.formatToISOString(testDate2, 'YYYY-MM-DDTHH:mm:ss')).toEqual('2020-11-11T23:23:23');
+      expect(DateUtil.formatToISOString(testDate2, { format: 'YYYY-MM-DD' })).toEqual('2020-11-11');
+      expect(DateUtil.formatToISOString(testDate2, { format: 'YYYY-MM-DDTHH:mm:ss.SSS' })).toEqual(
+        '2020-11-11T23:23:23.999'
+      );
+      expect(DateUtil.formatToISOString(testDate2, { format: 'YYYY-MM-DDTHH:mm:ss' })).toEqual('2020-11-11T23:23:23');
     });
   });
 

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -305,6 +305,7 @@ describe('DateUtil', () => {
       );
       expect(DateUtil.format(testDate1, { format: 'M/D' })).toEqual('1/1');
       expect(DateUtil.format(testDate1, { format: 'MM월 DD일' })).toEqual('01월 01일');
+      expect(DateUtil.format(testDate1, { format: 'YY/MM/DD' })).toEqual('20/01/01');
 
       const testDate2 = new Date('2020-11-11 23:23:23:999');
       expect(DateUtil.format(testDate2, { format: 'YYYY-MM-DD HH:mm:ss' })).toEqual('2020-11-11 23:23:23');
@@ -315,6 +316,7 @@ describe('DateUtil', () => {
       );
       expect(DateUtil.format(testDate2, { format: 'M/D' })).toEqual('11/11');
       expect(DateUtil.format(testDate2, { format: 'MM월 DD일' })).toEqual('11월 11일');
+      expect(DateUtil.format(testDate2, { format: 'YY/MM/DD' })).toEqual('20/11/11');
     });
 
     it('should format date to string with default format rule', () => {

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -270,9 +270,9 @@ describe('DateUtil', () => {
   });
 
   describe('setUTCOffset', () => {
-    it('should return date with UTCOffsetMin', () => {
+    it('should return date with UTCOffsetMinute', () => {
       const testDate1 = new Date('2020-01-01T01:01:01Z');
-      expect(DateUtil.setUTCOffset(testDate1, 180)).toHaveProperty('UTCOffsetMin');
+      expect(DateUtil.setUTCOffset(testDate1, 180)).toHaveProperty('UTCOffsetMinute');
       expect(DateUtil.setUTCOffset(testDate1, 180)).toBeInstanceOf(Date);
     });
   });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -311,6 +311,10 @@ describe('DateUtil', () => {
       const testDate2 = DateUtil.setUTCOffset(new Date('2000-01-01T09:00:00+09:00'), 540);
       expect(DateUtil.format(testDate2)).toBe('2000-01-01T09:00:00+09:00');
       expect(DateUtil.format(testDate2, 'M월 D일 H시 m분')).toBe('1월 1일 9시 0분');
+
+      const testDate3 = DateUtil.setUTCOffset(new Date('2000-01-01T00:00:00Z'), -300);
+      expect(DateUtil.format(testDate3)).toBe('1999-12-31T19:00:00-05:00');
+      expect(DateUtil.format(testDate3, 'M월 D일 H시 m분')).toBe('12월 31일 19시 0분');
     });
   });
 

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -250,7 +250,7 @@ export namespace DateUtil {
         case 'YYYY':
           return String(dateInfo.year);
         case 'YY':
-          return String(dateInfo.year).padStart(2, '0');
+          return String(dateInfo.year % 100).padStart(2, '0');
 
         case 'MM':
           return String(dateInfo.month).padStart(2, '0');

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -7,7 +7,8 @@ const ONE_DAY_IN_SECOND = 60 * 60 * 24;
 const ONE_HOUR_IN_SECOND = 60 * 60;
 const ONE_MINUTE_IN_SECOND = 60;
 
-const DEFAULT_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss+';
+const CUSTOM_OFFSET_FORMAT = 'K';
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss' + CUSTOM_OFFSET_FORMAT;
 
 const logger = LoggerFactory.getLogger('pebbles:date-util');
 
@@ -243,12 +244,12 @@ export namespace DateUtil {
     if (d instanceof Day1D && d.UTCOffsetMin) {
       formatResult = replaceDateFormat(format, dateUTCInfo);
       if (format === DEFAULT_DATE_FORMAT) {
-        formatResult += formatGMTOffset(d.UTCOffsetMin);
+        formatResult = formatGMTOffset(formatResult, d.UTCOffsetMin);
       }
     } else {
       formatResult = replaceDateFormat(format, dateInfo);
       if (format === DEFAULT_DATE_FORMAT) {
-        formatResult += formatGMTOffset(-d.getTimezoneOffset());
+        formatResult = formatGMTOffset(formatResult, -d.getTimezoneOffset());
       }
     }
     return formatResult;
@@ -350,18 +351,19 @@ function replaceDateFormat(format: string, dateInfo: DateInfo) {
   return formattedDate;
 }
 
-function formatGMTOffset(min: number) {
+function formatGMTOffset(d: string, min: number) {
+  const sign = min < 0 ? '-' : '+';
   const dateInfo = {
     year: 0,
     month: 0,
     date: 0,
-    hour: Math.floor(min / 60),
-    minute: Math.floor(min % 60),
+    hour: Math.floor(Math.abs(min) / 60),
+    minute: Math.floor(Math.abs(min) % 60),
     second: 0,
     millisecond: 0,
   };
 
-  return replaceDateFormat('HH:mm', dateInfo);
+  return d.replace(CUSTOM_OFFSET_FORMAT, sign + replaceDateFormat('HH:mm', dateInfo));
 }
 
 function isValidDate(d: Date): boolean {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -210,11 +210,11 @@ export namespace DateUtil {
     return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
   }
 
-  export function setUTCOffset(d: DateType, offsetMin: number): Date {
+  export function setUTCOffset(d: DateType, offsetMinute: number): Date {
     const UTCDate = new Day1D(getUTCTime(d));
 
-    UTCDate.setTime(UTCDate.getTime() + offsetMin * ONE_MINUTE_IN_SECOND * ONE_SECOND);
-    UTCDate.UTCOffsetMin = offsetMin;
+    UTCDate.setTime(UTCDate.getTime() + offsetMinute * ONE_MINUTE_IN_SECOND * ONE_SECOND);
+    UTCDate.UTCOffsetMinute = offsetMinute;
     return UTCDate;
   }
 
@@ -241,10 +241,10 @@ export namespace DateUtil {
       millisecond: d.getUTCMilliseconds(),
     };
 
-    if (d instanceof Day1D && d.UTCOffsetMin) {
+    if (d instanceof Day1D && d.UTCOffsetMinute) {
       formatResult = replaceDateFormat(format, dateUTCInfo);
       if (format === DEFAULT_DATE_FORMAT) {
-        formatResult = formatGMTOffset(formatResult, d.UTCOffsetMin);
+        formatResult = formatGMTOffset(formatResult, d.UTCOffsetMinute);
       }
     } else {
       formatResult = replaceDateFormat(format, dateInfo);
@@ -276,7 +276,7 @@ export namespace DateUtil {
 }
 
 class Day1D extends Date {
-  public UTCOffsetMin: number | undefined;
+  public UTCOffsetMinute: number | undefined;
 
   constructor(d: DateType) {
     super(d);
@@ -351,14 +351,14 @@ function replaceDateFormat(format: string, dateInfo: DateInfo) {
   return formattedDate;
 }
 
-function formatGMTOffset(d: string, min: number) {
-  const sign = min < 0 ? '-' : '+';
+function formatGMTOffset(d: string, minute: number) {
+  const sign = minute < 0 ? '-' : '+';
   const dateInfo = {
     year: 0,
     month: 0,
     date: 0,
-    hour: Math.floor(Math.abs(min) / 60),
-    minute: Math.floor(Math.abs(min) % 60),
+    hour: Math.floor(Math.abs(minute) / 60),
+    minute: Math.floor(Math.abs(minute) % 60),
     second: 0,
     millisecond: 0,
   };

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -7,6 +7,8 @@ const ONE_DAY_IN_SECOND = 60 * 60 * 24;
 const ONE_HOUR_IN_SECOND = 60 * 60;
 const ONE_MINUTE_IN_SECOND = 60;
 
+const DEFAULT_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss+';
+
 const logger = LoggerFactory.getLogger('pebbles:date-util');
 
 export namespace DateUtil {
@@ -215,7 +217,7 @@ export namespace DateUtil {
     return UTCDate;
   }
 
-  export function format(d: Date | Day1D, format: string): string {
+  export function format(d: Date | Day1D, format = DEFAULT_DATE_FORMAT): string {
     let formatResult;
 
     if (d instanceof Day1D && d.UTCOffsetMin) {
@@ -229,6 +231,9 @@ export namespace DateUtil {
         d.getUTCSeconds(),
         d.getUTCMilliseconds()
       );
+      if (format === DEFAULT_DATE_FORMAT) {
+        formatResult += formatGMTOffset(d.UTCOffsetMin);
+      }
     } else {
       formatResult = replaceDateFormat(
         format,
@@ -240,6 +245,9 @@ export namespace DateUtil {
         d.getSeconds(),
         d.getMilliseconds()
       );
+      if (format === DEFAULT_DATE_FORMAT) {
+        formatResult += formatGMTOffset(-d.getTimezoneOffset());
+      }
     }
     return formatResult;
   }
@@ -347,6 +355,10 @@ function replaceDateFormat(
   }
 
   return formattedDate;
+}
+
+function formatGMTOffset(min: number) {
+  return replaceDateFormat('HH:mm', 0, 0, 0, min / 60, min % 60, 0, 0);
 }
 
 function isValidDate(d: Date): boolean {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- utcOffset 구현 -> 동사형인 offsetUTC로 함수명 변경
- format함수에 분기 추가. default format 인자 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
- 기존 dateUtil의 utcOffset 결과물은 Moment<>의 instance였는데, 여기서 offset값이 있냐 없냐에 따라 다르게 표현되었습니다. (`Moment<2020-01-01T03:00:00+03:00>` or `Moment<2020-01-01T00:00:00Z>`)
~~이와 유사하게 가기 위해 Date를 상속받은 임의의 class를 만들어 해당 클래스 인스턴스에 offset property를 부여하는 방식으로 접근해봤습니다.~~

- utcOffset은 결과값이 그대로 쓰이지 않고 보통 format함수가 그 값을 감싸는 방식으로 사용되기에 format함수의 수정도 필요했습니다.
- 기존의 format 함수는 런타임 로컬 타임존에 영향을 받기 때문에 그대로 사용할 수 없어서 format 함수도 수정했습니다.


## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="336" alt="Screen Shot 2021-11-17 at 11 14 09 PM" src="https://user-images.githubusercontent.com/63729090/142216782-c21e5da7-56bf-4bad-b332-f325379e4cd1.png">

