### PR TITLE
feat: string-util에 renderTemplate 함수 추가

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -1,6 +1,49 @@
 import { StringUtil } from './string-util';
 
 describe('StringUtil', () => {
+  describe('renderTemplate', () => {
+    it('should render a template with double brackets', () => {
+      const testTemplate1 = 'Hello {{name}}!';
+      const testTemplate2 = '[{{site}}] 가입을 환영합니다 {{name}}님!';
+
+      expect(StringUtil.renderTemplate(testTemplate1, { name: 'World' })).toEqual('Hello World!');
+      expect(StringUtil.renderTemplate(testTemplate1, { name: 'World', foo: 'bar' })).toEqual('Hello World!');
+      expect(StringUtil.renderTemplate(testTemplate2, { site: '콜로소', name: '아무개' })).toEqual(
+        '[콜로소] 가입을 환영합니다 아무개님!'
+      );
+    });
+
+    it('should render a template with triple brackets as HTML tag', () => {
+      const testTemplate = '{{{test}}} 👈🏻 이건 HTML tag고, {{test}} 👈🏻 이건 이스케이프된 문자입니다';
+      expect(StringUtil.renderTemplate(testTemplate, { test: '<h1>Hello</h1>' })).toEqual(
+        '<h1>Hello</h1> 👈🏻 이건 HTML tag고, &lt;h1&gt;Hello&lt;/h1&gt; 👈🏻 이건 이스케이프된 문자입니다'
+      );
+    });
+
+    it('should render a template section', () => {
+      const testTemplate1 = '{{#courses}}<b>{{title}}</b>{{/courses}}';
+      const view1 = {
+        courses: [{ title: '엑셀' }, { title: '자바' }, { title: '도커' }],
+      };
+
+      const testTemplate2 = '{{#nameList}}{{name}} {{/nameList}}';
+      const view2 = {
+        nameList: [{ name: 'FOO' }, { name: 'BAR' }, { name: 'BAZ' }],
+      };
+
+      expect(StringUtil.renderTemplate(testTemplate1, view1)).toEqual('<b>엑셀</b><b>자바</b><b>도커</b>');
+      expect(StringUtil.renderTemplate(testTemplate2, view2)).toEqual('FOO BAR BAZ ');
+    });
+
+    it('should render a template with partial', () => {
+      const template = '[문자테스트] 안내문자입니다 {{> partial}}';
+      const partial = { partial: '문의사항은 아래링크로' };
+      expect(StringUtil.renderTemplate(template, {}, partial)).toEqual(
+        '[문자테스트] 안내문자입니다 문의사항은 아래링크로'
+      );
+    });
+  });
+
   describe('normalizePhoneNumber', () => {
     it('should normalize phone number starting with 010 or 070', () => {
       expect(StringUtil.normalizePhoneNumber('01012345678')).toBe('01012345678');

--- a/src/string-util/string-util.type.ts
+++ b/src/string-util/string-util.type.ts
@@ -1,0 +1,1 @@
+export type TemplateViewContent = string | Array<Record<string, string>>;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- mustache의 의존성 제거를 위한 render 셀프 구현
- render의 기능 중 `redstone/util/str.spec.js`에 명시되어 있는 부분만 일단 구현했습니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
- 테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.

<img width="512" alt="Screen Shot 2021-11-23 at 10 51 23 AM" src="https://user-images.githubusercontent.com/63729090/142960328-f264e8f2-91ae-4cb8-9851-8dac08cf2248.png">

