### PR TITLE
feat: string util의 renderTemplate 함수 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "axios": "^0.21.4",
         "jsonwebtoken": "^8.5.1",
+        "mustache": "^4.2.0",
         "pino": "^6.13.2"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
         "@types/jsonwebtoken": "^8.5.5",
+        "@types/mustache": "^4.1.2",
         "@types/node": "^16.7.13",
         "@types/pino": "^6.3.11",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
@@ -1233,6 +1235,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mustache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.2.tgz",
+      "integrity": "sha512-c4OVMMcyodKQ9dpwBwh3ofK9P6U9ZktKU9S+p33UqwMNN1vlv2P0zJZUScTshnx7OEoIIRcCFNQ904sYxZz8kg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.10.3",
@@ -4847,6 +4855,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7360,6 +7376,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/mustache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.2.tgz",
+      "integrity": "sha512-c4OVMMcyodKQ9dpwBwh3ofK9P6U9ZktKU9S+p33UqwMNN1vlv2P0zJZUScTshnx7OEoIIRcCFNQ904sYxZz8kg==",
+      "dev": true
     },
     "@types/node": {
       "version": "16.10.3",
@@ -10098,6 +10120,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "dependencies": {
     "axios": "^0.21.4",
     "jsonwebtoken": "^8.5.1",
+    "mustache": "^4.2.0",
     "pino": "^6.13.2"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/jsonwebtoken": "^8.5.5",
+    "@types/mustache": "^4.1.2",
     "@types/node": "^16.7.13",
     "@types/pino": "^6.3.11",
     "@typescript-eslint/eslint-plugin": "^4.31.1",

--- a/src/string-util/string-util.interface.ts
+++ b/src/string-util/string-util.interface.ts
@@ -1,3 +1,10 @@
 export interface Tag {
   text: string;
 }
+
+export interface TemplateOpts {
+  readonly template: string;
+  readonly view: Record<string, unknown>;
+  readonly partial?: Record<string, string>;
+  readonly customTag?: string[];
+}

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -26,6 +26,69 @@ describe('StringUtil', () => {
     });
   });
 
+  describe('renderTemplate', () => {
+    it('should render a template with double brackets', () => {
+      const testOpt1 = { template: 'Hello {{name}}!', view: { name: 'World' } };
+      const testOpt2 = {
+        template: '[{{site}}] 가입을 환영합니다 {{name}}님!',
+        view: { site: '콜로소', name: '아무개' },
+      };
+      expect(StringUtil.renderTemplate(testOpt1)).toEqual('Hello World!');
+      expect(StringUtil.renderTemplate(testOpt2)).toEqual('[콜로소] 가입을 환영합니다 아무개님!');
+    });
+
+    it('should render a template with triple brackets as HTML tag', () => {
+      const testOpt = {
+        template: '<div>{{{hello}}}</div>',
+        view: { hello: '<h1>Hello</h1>' },
+      };
+      expect(StringUtil.renderTemplate(testOpt)).toEqual('<div><h1>Hello</h1></div>');
+    });
+
+    it('should render a template section', () => {
+      const testOpt1 = {
+        template: '{{#courses}}<b>{{title}}</b>{{/courses}}',
+        view: {
+          courses: [{ title: '엑셀' }, { title: '자바' }, { title: '도커' }],
+        },
+      };
+      const testOpt2 = {
+        template: '{{#nameList}}{{name}} {{/nameList}}',
+        view: {
+          nameList: [{ name: 'FOO' }, { name: 'BAR' }, { name: 'BAZ' }],
+        },
+      };
+      expect(StringUtil.renderTemplate(testOpt1)).toEqual('<b>엑셀</b><b>자바</b><b>도커</b>');
+      expect(StringUtil.renderTemplate(testOpt2)).toEqual('FOO BAR BAZ ');
+    });
+
+    it('should render a template with partial', () => {
+      const testOpt = {
+        template: '[문자테스트] 안내문자입니다 {{> partial}}',
+        view: {},
+        partial: { partial: '문의사항은 아래링크로' },
+      };
+      expect(StringUtil.renderTemplate(testOpt)).toEqual('[문자테스트] 안내문자입니다 문의사항은 아래링크로');
+    });
+
+    it('should render a template with custom tags', () => {
+      const testOpt = {
+        template: '%{hello}, {{name}}',
+        view: { hello: '안녕하세요' },
+        customTag: ['%{', '}'],
+      };
+      expect(StringUtil.renderTemplate(testOpt)).toEqual('안녕하세요, {{name}}');
+    });
+
+    it('should throw with unclosed tag', () => {
+      const testOpt = {
+        template: '{{hello}',
+        view: { hello: '안녕하세요' },
+      };
+      expect(() => StringUtil.renderTemplate(testOpt)).toThrow();
+    });
+  });
+
   describe('normalizePhoneNumber', () => {
     it('should normalize phone number starting with 010 or 070', () => {
       expect(StringUtil.normalizePhoneNumber('01012345678')).toBe('01012345678');

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,10 +1,16 @@
-import type { Tag } from './string-util.interface';
+import Mustache from 'mustache';
+import type { Tag, TemplateOpts } from './string-util.interface';
 
 const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
 
 export namespace StringUtil {
   export function getNonce(nonceLength: number, nonceEncoding: number): string {
     return Math.random().toString(nonceEncoding).substr(-nonceLength);
+  }
+
+  export function renderTemplate(templateOpts: TemplateOpts): string {
+    const { template, view, partial, customTag } = templateOpts;
+    return Mustache.render(template, view, partial, customTag as [string, string]);
   }
 
   export function normalizePhoneNumber(str: string): string {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
util/str의 renderTemplate
lodash 제거를 위해 util/str의 interpolate를 render의 customTag 사용으로 대체하려 합니다.
(현재 interpolate는 messageService에서 사용중입니다)

## 디펜던시 변경이 있나요?
mustache dependency 추가

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
<img width="518" alt="Screen Shot 2021-12-02 at 2 52 21 PM" src="https://user-images.githubusercontent.com/63729090/144365606-ea4ba8c8-ab10-41a3-9da8-c4172279bd0f.png">
