### PR TITLE
fix: replace split function with spread operator at string-util

### DIFF
--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -4,10 +4,10 @@ const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
 
 export namespace StringUtil {
   export function midMask(str: string, startIndex: number, length: number, maskChar = '*'): string {
-    const strList = str.split('');
-    const maskingPart = maskChar.repeat(length).split('');
+    const strList = [...str];
+    const maskingPart = maskChar.repeat(length);
 
-    strList.splice(startIndex, length, ...maskingPart);
+    strList.splice(startIndex, length, maskingPart);
     return strList.join('');
   }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://github.com/day1co/pebbles/pull/54#discussion_r760859294

## 무엇을 어떻게 변경했나요?
문자열 -> 배열 치환 부분을 split('') 대신 spread operator를 사용하도록 수정
maskingPart가 배열이 아니어도 되기에 string 타입을 계속 유지하도록 변경

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그가 있다면 첨부해주세요.
