### PR TITLE
tsc outDir이 프로젝트 root가 되도록 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,6 @@ module.exports = {
     node: true,
   },
   extends: ['plugin:prettier/recommended', 'prettier', 'plugin:@typescript-eslint/recommended'],
-  ignorePatterns: ['dist'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,16 @@
 node_modules/
-dist/
 coverage/
 .idea
 .DS_Store
+
+# Build results
+index.*
+boolean-util/
+date-util/
+http-client/
+json-web-token/
+logger/
+misc-util/
+number-util/
+object-util/
+string-util/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+src
+jest.config.cjs
+tsconfig.json
+.*

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
-    "build": "rimraf ./dist & tsc",
-    "clean": "rimraf ./dist ./node_modules",
+    "build": "tsc",
+    "clean": "npm run removeOldBuild && rimraf ./node_modules",
     "lint": "eslint .",
-    "prebuild": "npm run lint",
+    "prebuild": "npm run removeOldBuild && npm run lint",
     "prepublishOnly": "npm run build",
+    "removeOldBuild": "rimraf `find . -type d -maxdepth 1 ! -name src ! -name \".*\" ! -name node_modules` index.*",
     "test": "jest --detectOpenHandles --forceExit ./src"
   },
-  "type": "module",
   "dependencies": {
     "axios": "^0.21.4",
     "jsonwebtoken": "^8.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+export { BooleanUtil } from './boolean-util';
+export { DateUtil } from './date-util';
+export type { DateType, CalcDatetimeOpts } from './date-util';
+export { HttpClient, HttpState } from './http-client';
+export type { HttpReqConfig, HttpRes } from './http-client';
+export { LoggerFactory } from './logger';
+export type { Logger, LogLevel } from './logger';
+export { MiscUtil } from './misc-util';
+export type { PageInfo, Pagination, PageDetail } from './misc-util';
+export { NumberUtil } from './number-util';
+export { ObjectUtil } from './object-util';
+export { StringUtil } from './string-util';
+export type { Tag } from './string-util';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "strict": true,
-    "module": "es2020",
+    "module": "commonjs",
     "moduleResolution": "node",
     "types": ["node", "jest"],
     "declaration": true,
     "newLine": "lf",
-    "outDir": "dist",
+    "outDir": "./",
     "sourceMap": true,
     "allowJs": true,
     "checkJs": true,
@@ -17,6 +17,6 @@
     "esModuleInterop": true,
     "target": "es2021"
   },
-  "include": ["src"],
-  "exclude": ["dist", "node_modules", "**/*.spec.ts"]
+  "include": ["./src"],
+  "exclude": ["./node_modules", "./**/*.spec.ts"]
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
pebbles를 import할 때
`
require('@day1co/pebbles/logger');
`
와 같이 하위 모듈을 가져올 수 있게 한다.

## 무엇을 어떻게 변경했나요?
tsconfig.json의 outDir을 프로젝트 루트로 변경
package.json 변경

## 어떻게 테스트 하셨나요?
npm run build
npm publish
npm run clean

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="555" alt="스크린샷 2021-12-08 오전 12 24 37" src="https://user-images.githubusercontent.com/38378806/145126140-5790631f-a3f5-4f48-b6b5-9ea14d5ca8d7.png">

<img width="529" alt="스크린샷 2021-12-08 오전 12 24 46" src="https://user-images.githubusercontent.com/38378806/145126026-d6a27e69-8962-4e9a-8e38-ce3825abc638.png">
