### PR TITLE
npm token 이름 정정

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Prepare dot npmrc for private registry
-        run: echo //npm.pkg.github.com/:_authToken=${{ secrets.GH_NPM_TOKEN }} >> ~/.npmrc
+        run: echo //npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }} >> ~/.npmrc
       - name: Bootstrap
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,8 +18,8 @@ defaults:
     shell: bash
 
 env:
-  PUSH_TOKEN: ${{ secrets.GH_NPM_TOKEN }}
-  PACKAGE_TOKEN: ${{ secrets.GH_NPM_TOKEN }}
+  PUSH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  PACKAGE_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   check-pusher:


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
day1co에서 사용하는 npm token의 이름은 NPM_TOKEN이다.

## 무엇을 어떻게 변경했나요?
GH_NPM_TOKEN을 NPM_TOKEN으로 변경
