### PR TITLE
workflow: publish할 때 package-lock.json 도 커밋에 포함하도록 수정

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -98,7 +98,7 @@ jobs:
           PACKAGE_NAME=$(jq -r .name package.json)
           PACKAGE_VERSION=$(jq -r .version package.json)
 
-          git commit -m "$PACKAGE_NAME: bump up to $PACKAGE_VERSION" package.json
+          git commit -m "$PACKAGE_NAME: bump up to $PACKAGE_VERSION" package.json package-lock.json
           git pull --rebase
           git push origin
       - name: publish


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
* main에 코드가 병합되고나면 자동으로 npm 배포가 되어야 한다.
하지만 action에서 오류가 발생 중 [참고](https://github.com/day1co/pebbles/actions/runs/1576562454)

## 무엇을 어떻게 변경했나요?
* npm patch 를 하게되면 package-lock.json도 변경되는데 commit에 추가하지 않고있어서 이를 추가함

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
![스크린샷 2021-12-15 오전 10 37 15](https://user-images.githubusercontent.com/39257313/146106871-f00f2e83-e858-4ddc-9294-958ae4eaf41b.png)

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
