### PR TITLE
FIX: git commit with package-lock.json

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -98,7 +98,9 @@ jobs:
           PACKAGE_NAME=$(jq -r .name package.json)
           PACKAGE_VERSION=$(jq -r .version package.json)
 
-          git commit -m "$PACKAGE_NAME: bump up to $PACKAGE_VERSION" package.json
+          git status
+          
+          git commit -m "$PACKAGE_NAME: bump up to $PACKAGE_VERSION" package.json package-lock.json
           git pull --rebase
           git push origin
       - name: publish


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

워크플로우 작동 실패 

## 무엇을 어떻게 변경했나요?

* `npm version patch` 이후 `package-lock.json` 커밋 추가 
* 커밋 전 `git status` 로 누락된 파일 확인 가능하도록 처리

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

기존 워크플로우가 npm workspace 기준이어서 커밋시 package-lock.json 을 사용하지 않았고, 현재는 필요하여 추가했습니다.

