### PR TITLE
deepClone 대상을 object로 제한함

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -101,9 +101,5 @@ describe('ObjectUtil', () => {
       expect(clonedSet).not.toBe(set);
       expect(clonedSet).toEqual(set);
     });
-    it('should throw error', () => {
-      const buffer = Buffer.alloc(10);
-      expect(() => ObjectUtil.deepClone(buffer)).toThrow();
-    });
   });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -64,7 +64,6 @@ describe('ObjectUtil', () => {
       expect(ObjectUtil.isEmpty(' ')).toBe(false);
       expect(ObjectUtil.isEmpty(new Set([1, 2, 3, 'foo', {}]))).toBe(false);
       expect(ObjectUtil.isEmpty(new Map([['foo', 1]]))).toBe(false);
-      expect(ObjectUtil.isEmpty(Buffer.alloc(1))).toBe(false);
     });
   });
 

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -70,17 +70,10 @@ describe('ObjectUtil', () => {
 
   describe('deepClone', () => {
     it('should return deep cloned object', () => {
-      const obj = {
-        a: 1,
-        b: {
-          c: 2,
-        },
-      };
+      const obj = { foo: 1, bar: { baz: 2 } };
       const clonedObj = ObjectUtil.deepClone(obj);
       expect(clonedObj).not.toBe(obj);
-      expect(obj.a).toEqual(clonedObj.a);
-      expect(obj.b).toEqual(clonedObj.b);
-      expect(obj.b.c).toEqual(clonedObj.b.c);
+      expect(clonedObj).toEqual(obj);
     });
   });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -81,15 +81,44 @@ describe('ObjectUtil', () => {
       expect(clonedInterfaceObj).not.toBe(interfaceObj);
       expect(clonedInterfaceObj).toEqual(interfaceObj);
 
+      class TestClass {
+        private _foo: number;
+
+        constructor(arg: number) {
+          this._foo = arg;
+        }
+
+        get foo(): number {
+          return this._foo;
+        }
+
+        set foo(arg: number) {
+          this._foo = arg;
+        }
+      }
+      const classObj: TestClass = new TestClass(1);
+      const clonedClassObj = ObjectUtil.deepClone<TestClass>(classObj);
+      expect(clonedClassObj instanceof TestClass).toBe(true);
+      expect(clonedClassObj).not.toBe(classObj);
+      expect(clonedClassObj).toEqual(classObj);
+
       const array = ['foo', { bar: 1 }];
       const clonedArray = ObjectUtil.deepClone<(string | Bar)[]>(array);
+      expect(clonedArray instanceof Array).toBe(true);
       expect(clonedArray).not.toBe(array);
       expect(clonedArray).toEqual(array);
+
+      const date = new Date();
+      const clonedDate = ObjectUtil.deepClone<Date>(date);
+      expect(clonedDate instanceof Date).toBe(true);
+      expect(clonedDate).not.toBe(date);
+      expect(clonedDate).toEqual(date);
 
       const map = new Map<string, number | Bar>();
       map.set('foo', 1);
       map.set('bar', { bar: 2 });
       const clonedMap = ObjectUtil.deepClone<Map<string, number | Bar>>(map);
+      expect(clonedMap instanceof Map).toBe(true);
       expect(clonedMap).not.toBe(map);
       expect(clonedMap).toEqual(map);
 
@@ -97,8 +126,13 @@ describe('ObjectUtil', () => {
       set.add('foo');
       set.add({ bar: 1 });
       const clonedSet = ObjectUtil.deepClone<Set<string | Bar>>(set);
+      expect(clonedSet instanceof Set).toBe(true);
       expect(clonedSet).not.toBe(set);
       expect(clonedSet).toEqual(set);
+    });
+    it('should throw error', () => {
+      const buffer = Buffer.alloc(10);
+      expect(() => ObjectUtil.deepClone<Buffer>(buffer)).toThrow('Not supported type');
     });
   });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -82,8 +82,8 @@ describe('ObjectUtil', () => {
       expect(clonedInterfaceObj).not.toBe(interfaceObj);
       expect(clonedInterfaceObj).toEqual(interfaceObj);
 
-      const array = ['foo', 'bar'];
-      const clonedArray = ObjectUtil.deepClone<string[]>(array);
+      const array = ['foo', { bar: 1 }];
+      const clonedArray = ObjectUtil.deepClone<(string | Bar)[]>(array);
       expect(clonedArray).not.toBe(array);
       expect(clonedArray).toEqual(array);
 

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -132,7 +132,7 @@ describe('ObjectUtil', () => {
     });
     it('should throw error', () => {
       const buffer = Buffer.alloc(10);
-      expect(() => ObjectUtil.deepClone<Buffer>(buffer)).toThrow('Not supported type');
+      expect(() => ObjectUtil.deepClone<Buffer>(buffer)).toThrow();
     });
   });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -70,10 +70,29 @@ describe('ObjectUtil', () => {
 
   describe('deepClone', () => {
     it('should return deep cloned object', () => {
-      const obj = { foo: 1, bar: { baz: 2 } };
-      const clonedObj = ObjectUtil.deepClone(obj);
-      expect(clonedObj).not.toBe(obj);
-      expect(clonedObj).toEqual(obj);
+      interface TestInterface {
+        foo: number;
+        bar: { baz: number };
+      }
+      const interfaceObj: TestInterface = { foo: 1, bar: { baz: 2 } };
+      const clonedInterfaceObj = ObjectUtil.deepClone<TestInterface>(interfaceObj);
+      expect(clonedInterfaceObj).not.toBe(interfaceObj);
+      expect(clonedInterfaceObj).toEqual(interfaceObj);
+
+      const array = ['foo', 'bar'];
+      const clonedArray = ObjectUtil.deepClone<string[]>(array);
+      expect(clonedArray).not.toBe(array);
+      expect(clonedArray).toEqual(array);
+
+      // Todo: 아래 형태들도 지원해야 함
+      const map = new Map<string, number>();
+      map.set('foo', 1);
+      map.set('bar', 2);
+      expect(() => ObjectUtil.deepClone(map)).toThrow();
+      const set = new Set<string>();
+      set.add('foo');
+      set.add('bar');
+      expect(() => ObjectUtil.deepClone(set)).toThrow();
     });
   });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -71,10 +71,13 @@ describe('ObjectUtil', () => {
   describe('deepClone', () => {
     it('should return deep cloned object', () => {
       interface TestInterface {
-        foo: number;
-        bar: { baz: number };
+        foo: Bar;
+        baz: number;
       }
-      const interfaceObj: TestInterface = { foo: 1, bar: { baz: 2 } };
+      interface Bar {
+        bar: number;
+      }
+      const interfaceObj: TestInterface = { foo: { bar: 1 }, baz: 2 };
       const clonedInterfaceObj = ObjectUtil.deepClone<TestInterface>(interfaceObj);
       expect(clonedInterfaceObj).not.toBe(interfaceObj);
       expect(clonedInterfaceObj).toEqual(interfaceObj);
@@ -84,15 +87,23 @@ describe('ObjectUtil', () => {
       expect(clonedArray).not.toBe(array);
       expect(clonedArray).toEqual(array);
 
-      // Todo: 아래 형태들도 지원해야 함
-      const map = new Map<string, number>();
+      const map = new Map<string, number | Bar>();
       map.set('foo', 1);
-      map.set('bar', 2);
-      expect(() => ObjectUtil.deepClone(map)).toThrow();
-      const set = new Set<string>();
+      map.set('bar', { bar: 2 });
+      const clonedMap = ObjectUtil.deepClone<Map<string, number | Bar>>(map);
+      expect(clonedMap).not.toBe(map);
+      expect(clonedMap).toEqual(map);
+
+      const set = new Set<string | { bar: number }>();
       set.add('foo');
-      set.add('bar');
-      expect(() => ObjectUtil.deepClone(set)).toThrow();
+      set.add({ bar: 1 });
+      const clonedSet = ObjectUtil.deepClone<Set<string | Bar>>(set);
+      expect(clonedSet).not.toBe(set);
+      expect(clonedSet).toEqual(set);
+    });
+    it('should throw error', () => {
+      const buffer = Buffer.alloc(10);
+      expect(() => ObjectUtil.deepClone(buffer)).toThrow();
     });
   });
 });

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -41,8 +41,8 @@ export namespace ObjectUtil {
   export function deepClone<Type>(obj: Type): Type {
     if (!(obj instanceof Object)) {
       throw new Error('Should be an object type');
-    } else if (obj instanceof Map || obj instanceof Set) {
-      throw new Error('Map or Set is not supported type yet');
+    } else if (obj instanceof Map || obj instanceof Set || obj instanceof Buffer) {
+      throw new Error('Map/Set/Buffer is not a supported type yet');
     }
 
     return JSON.parse(JSON.stringify(obj));

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -37,7 +37,14 @@ export namespace ObjectUtil {
     return true;
   }
 
-  export function deepClone<T extends Record<string, unknown>>(obj: T): T {
+  // Todo: Map과 Set 등의 특정 Object type에 대한 지원 필요
+  export function deepClone<Type>(obj: Type): Type {
+    if (!(obj instanceof Object)) {
+      throw new Error('Should be an object type');
+    } else if (obj instanceof Map || obj instanceof Set) {
+      throw new Error('Map or Set is not supported type yet');
+    }
+
     return JSON.parse(JSON.stringify(obj));
   }
 }

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -51,8 +51,6 @@ export namespace ObjectUtil {
       case Set:
       case RegExp:
         return new constructorFunc(obj) as ObjectType;
-      case Buffer:
-        throw new Error('Not supported type');
       default:
         clonedObj = new constructorFunc();
     }

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -37,7 +37,7 @@ export namespace ObjectUtil {
     return true;
   }
 
-  export function deepClone<T>(obj: T): T {
-    return JSON.parse(JSON.stringify(obj)) as T;
+  export function deepClone<T extends Record<string, unknown>>(obj: T): T {
+    return JSON.parse(JSON.stringify(obj));
   }
 }

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -31,19 +31,14 @@ export namespace ObjectUtil {
       return !value.size;
     }
 
-    if (typeof value === 'string' || value instanceof Object || value instanceof Buffer) {
+    if (typeof value === 'string' || value instanceof Object) {
       return !Object.keys(value).length;
     }
 
     return true;
   }
 
-  // Todo: Buffer type에 대한 지원 필요
   export function deepClone<Type extends ObjectType>(obj: Type): Type {
-    if (obj instanceof Buffer) {
-      throw new Error('Buffer is not a supported type yet');
-    }
-
     if (obj instanceof (Map || Set)) {
       const result = new Map();
       const keys = Array.from(obj.keys());

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -1,4 +1,5 @@
 import { LoggerFactory } from '../logger';
+import { ObjectType } from './object-util.type';
 
 const logger = LoggerFactory.getLogger('pebbles:object-util');
 
@@ -37,12 +38,32 @@ export namespace ObjectUtil {
     return true;
   }
 
-  // Todo: Map과 Set 등의 특정 Object type에 대한 지원 필요
-  export function deepClone<Type>(obj: Type): Type {
-    if (!(obj instanceof Object)) {
-      throw new Error('Should be an object type');
-    } else if (obj instanceof Map || obj instanceof Set || obj instanceof Buffer) {
-      throw new Error('Map/Set/Buffer is not a supported type yet');
+  // Todo: Buffer type에 대한 지원 필요
+  export function deepClone<Type extends ObjectType>(obj: Type): Type {
+    if (obj instanceof Buffer) {
+      throw new Error('Buffer is not a supported type yet');
+    }
+
+    if (obj instanceof (Map || Set)) {
+      const result = new Map();
+      const keys = Array.from(obj.keys());
+
+      keys.forEach((key) => {
+        result.set(key, obj.get(key));
+      });
+
+      return result as ObjectType;
+    }
+
+    if (obj instanceof Set) {
+      const result = new Set();
+      const keys = Array.from(obj.keys());
+
+      keys.forEach((key) => {
+        result.add(key);
+      });
+
+      return result as ObjectType;
     }
 
     return JSON.parse(JSON.stringify(obj));

--- a/src/object-util/object-util.type.ts
+++ b/src/object-util/object-util.type.ts
@@ -1,0 +1,1 @@
+export type ObjectType = Record<any, any>;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
1. ObjectUtil이므로 deepClone()의 대상을 Object(aka Record<any, any>)로 제한한다.
2. 다만 Buffer 클래스 지원은 차후에 한다.
3. 객체의 값만 비교하는 것은 toEqual()을 쓰면 된다.
4. 테스트하는 객체 종류를 다양하게 만든다.

## 무엇을 어떻게 변경했나요?
Type별 객체 생성 코드 수정 및 테스트코드 추가

## 어떻게 테스트 하셨나요?
npm run test
