### PR TITLE
feat: object-util의 omit 구현

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -163,4 +163,41 @@ describe('ObjectUtil', () => {
       expect(ObjectUtil.merge(obj1, obj2, obj3)).toEqual(result);
     });
   });
+
+  describe('omit', () => {
+    interface TestObj {
+      foo: 1;
+      bar: 2;
+      baz?: unknown;
+    }
+    it('should return object with given keys deleted', () => {
+      const testObj1: TestObj = { foo: 1, bar: 2, baz: 3 };
+      const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } };
+      const testObj3: TestObj = { foo: 1, bar: 2, baz: [1, 2, 3] };
+      expect(ObjectUtil.omit<TestObj>(testObj1, ['foo', 'bar'])).toEqual({ baz: 3 });
+      expect(ObjectUtil.omit<TestObj>(testObj2, ['baz'])).toEqual({ foo: 1, bar: 2 });
+      expect(ObjectUtil.omit<TestObj>(testObj3, ['baz'])).toEqual({ foo: 1, bar: 2 });
+    });
+
+    it('should delete object keys flattened', () => {
+      const testObj1: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } };
+      const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: [1, 2], bar: { foo: 1, bar: 2 } } };
+      expect(ObjectUtil.omit<TestObj>(testObj1, ['baz.foo'])).toEqual({ foo: 1, bar: 2, baz: { bar: 2 } });
+      expect(ObjectUtil.omit<TestObj>(testObj2, ['foo', 'baz.bar.bar'])).toEqual({
+        bar: 2,
+        baz: { foo: [1, 2], bar: { foo: 1 } },
+      });
+    });
+
+    it('should not deform original object', () => {
+      const testObj1: TestObj = { foo: 1, bar: 2 };
+      const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } } };
+      const testResult1 = ObjectUtil.omit<TestObj>(testObj1, ['bar']);
+      const testResult2 = ObjectUtil.omit<TestObj>(testObj2, ['bar', 'baz.foo', 'baz.baz.bar']);
+      expect(testObj1).toEqual({ foo: 1, bar: 2 });
+      expect(testObj2).toEqual({ foo: 1, bar: 2, baz: { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } } });
+      expect(testObj1).not.toEqual(testResult1);
+      expect(testObj2).not.toEqual(testResult2);
+    });
+  });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -170,20 +170,21 @@ describe('ObjectUtil', () => {
       bar: 2;
       baz?: unknown;
     }
+
     it('should return object with given keys deleted', () => {
       const testObj1: TestObj = { foo: 1, bar: 2, baz: 3 };
       const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } };
       const testObj3: TestObj = { foo: 1, bar: 2, baz: [1, 2, 3] };
-      expect(ObjectUtil.omit<TestObj>(testObj1, ['foo', 'bar'])).toEqual({ baz: 3 });
-      expect(ObjectUtil.omit<TestObj>(testObj2, ['baz'])).toEqual({ foo: 1, bar: 2 });
-      expect(ObjectUtil.omit<TestObj>(testObj3, ['baz'])).toEqual({ foo: 1, bar: 2 });
+      expect(ObjectUtil.omit(testObj1, ['foo', 'bar'])).toEqual({ baz: 3 });
+      expect(ObjectUtil.omit(testObj2, ['baz'])).toEqual({ foo: 1, bar: 2 });
+      expect(ObjectUtil.omit(testObj3, ['baz'])).toEqual({ foo: 1, bar: 2 });
     });
 
     it('should delete object keys flattened', () => {
       const testObj1: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } };
       const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: [1, 2], bar: { foo: 1, bar: 2 } } };
-      expect(ObjectUtil.omit<TestObj>(testObj1, ['baz.foo'])).toEqual({ foo: 1, bar: 2, baz: { bar: 2 } });
-      expect(ObjectUtil.omit<TestObj>(testObj2, ['foo', 'baz.bar.bar'])).toEqual({
+      expect(ObjectUtil.omit(testObj1, ['baz.foo'])).toEqual({ foo: 1, bar: 2, baz: { bar: 2 } });
+      expect(ObjectUtil.omit(testObj2, ['foo', 'baz.bar.bar'])).toEqual({
         bar: 2,
         baz: { foo: [1, 2], bar: { foo: 1 } },
       });
@@ -192,12 +193,29 @@ describe('ObjectUtil', () => {
     it('should not deform original object', () => {
       const testObj1: TestObj = { foo: 1, bar: 2 };
       const testObj2: TestObj = { foo: 1, bar: 2, baz: { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } } };
-      const testResult1 = ObjectUtil.omit<TestObj>(testObj1, ['bar']);
-      const testResult2 = ObjectUtil.omit<TestObj>(testObj2, ['bar', 'baz.foo', 'baz.baz.bar']);
+      const testResult1 = ObjectUtil.omit(testObj1, ['bar']);
+      const testResult2 = ObjectUtil.omit(testObj2, ['bar', 'baz.foo', 'baz.baz.bar']);
       expect(testObj1).toEqual({ foo: 1, bar: 2 });
       expect(testObj2).toEqual({ foo: 1, bar: 2, baz: { foo: 1, bar: 2, baz: { foo: 1, bar: 2 } } });
       expect(testObj1).not.toEqual(testResult1);
       expect(testObj2).not.toEqual(testResult2);
+    });
+
+    it('should omit with number | symbol type key', () => {
+      const symbol1 = Symbol('foo');
+      const symbol2 = Symbol('bar');
+      const testObj1: { [key: symbol]: number } = {};
+      const testObj2: { [key: number]: number } = {};
+      testObj1[symbol1] = 1;
+      testObj1[symbol2] = 2;
+
+      const number1 = 1;
+      const number2 = 2;
+      testObj2[number1] = 1;
+      testObj2[number2] = 2;
+
+      expect(ObjectUtil.omit(testObj1, [symbol1])).toEqual({ [symbol2]: 2 });
+      expect(ObjectUtil.omit(testObj2, [1])).toEqual({ [2]: 2 });
     });
   });
 });

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -96,20 +96,26 @@ export namespace ObjectUtil {
     return result;
   }
 
-  // TODO: number, symbol 타입의 key를 포함하도록 수정
-  export function omit<Type extends ObjectType>(obj: Type, omitKeys: string[]): Type | Record<string, never> {
-    if (Object.keys(obj).length <= 0) {
+  export function omit(obj: ObjectType, omitKeys: ObjectKeyType[]): ObjectType {
+    const keys: ObjectKeyType[] = Object.getOwnPropertyNames(obj);
+    keys.push(...Object.getOwnPropertySymbols(obj));
+
+    if (keys.length <= 0) {
       return {};
     }
     if (omitKeys.length <= 0) {
       return obj;
     }
 
-    const resultObj = deepClone<Type>(obj);
+    const resultObj = deepClone(obj);
 
     for (const key of omitKeys) {
-      const nestedKeys = key.split('.');
       let tempObj = resultObj;
+      let nestedKeys: ObjectKeyType[] = [key];
+
+      if (typeof key === 'string') {
+        nestedKeys = key.split('.');
+      }
       for (let i = 0; i < nestedKeys.length; i++) {
         if (i === nestedKeys.length - 1) {
           delete tempObj[nestedKeys[i]];

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -95,4 +95,29 @@ export namespace ObjectUtil {
 
     return result;
   }
+
+  // TODO: number, symbol 타입의 key를 포함하도록 수정
+  export function omit<Type extends ObjectType>(obj: Type, omitKeys: string[]): Type | Record<string, never> {
+    if (Object.keys(obj).length <= 0) {
+      return {};
+    }
+    if (omitKeys.length <= 0) {
+      return obj;
+    }
+
+    const resultObj = deepClone<Type>(obj);
+
+    for (const key of omitKeys) {
+      const nestedKeys = key.split('.');
+      let tempObj = resultObj;
+      for (let i = 0; i < nestedKeys.length; i++) {
+        if (i === nestedKeys.length - 1) {
+          delete tempObj[nestedKeys[i]];
+          break;
+        }
+        tempObj = tempObj[nestedKeys[i]];
+      }
+    }
+    return resultObj;
+  }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
ts rewriting 및 lodash 패키지의 omit 기능 지원 중단

## 무엇을 어떻게 변경했나요?
lodash의 omit 기능을 참고해 object에서 key를 제거하는 함수를 구현합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
기존 함수 스펙은 아래와 같습니다.
1. 기존 object를 변형하지 않도록 합니다.
2. 삭제할 키가 `'a.b.c'` 이처럼 제공된다면, a 오브젝트의, b 오브젝트의, c 키 값을 제거해야 합니다.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="374" alt="Screen Shot 2021-12-30 at 6 01 07 PM" src="https://user-images.githubusercontent.com/63729090/147737066-97a0a2f7-3a10-4286-8110-98040f3c8d68.png">

