### PR TITLE
fix: BooleanUtil.valueOf의 불필요한 toLowerCase문을 삭제합니다

### DIFF
--- a/src/boolean-util/boolean-util.ts
+++ b/src/boolean-util/boolean-util.ts
@@ -3,10 +3,10 @@ export namespace BooleanUtil {
     const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
     const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
 
-    if (TRUE_REGEXP.test(boolStr.toLowerCase())) {
+    if (TRUE_REGEXP.test(boolStr)) {
       return true;
     }
-    if (!FALSE_REGEXP.test(boolStr.toLowerCase())) {
+    if (!FALSE_REGEXP.test(boolStr)) {
       throw new Error(`unable to convert "${boolStr}" to boolean type`);
     }
     return false;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
regexp 가 `/i` 로 끝나므로 toLowerCase() 를 호출할 필요가 없습니다.
**+ npm - publish 슬랙 메세지 테스트 용도의 pr이기도 합니다.**

## 무엇을 어떻게 변경했나요?
BooleanUtil.valueOf에 쓰인 toLowerCase() 함수 제거

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
