### PR TITLE
객체를 로깅할 때는 %o를 쓰도록 수정

### DIFF
--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -53,7 +53,7 @@ export namespace DateUtil {
 
       return date;
     } catch (err) {
-      logger.error('calcDatetime error: %s, %s, %s', err, d, JSON.stringify(opts));
+      logger.error('calcDatetime error: %s, %s, %o', err, d, opts);
       throw err;
     }
   }

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -21,35 +21,25 @@ export class HttpClient {
 
   sendGetRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`getRequest to %s with config: %s`, fullUrl, JSON.stringify(config));
+    this.logger.debug(`getRequest to %s with config: %o`, fullUrl, config);
     return axios.get<Type, HttpRes<Type>>(fullUrl, config);
   }
 
   sendPostRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(
-      `postRequest to %s with data: %s, config: %s `,
-      fullUrl,
-      JSON.stringify(data),
-      JSON.stringify(config)
-    );
+    this.logger.debug(`postRequest to %s with data: %o, config: %o`, fullUrl, data, config);
     return axios.post<Type, HttpRes<Type>>(fullUrl, data, config);
   }
 
   sendPutRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(
-      `putRequest to %s with data: %s, config: %s`,
-      fullUrl,
-      JSON.stringify(data),
-      JSON.stringify(config)
-    );
+    this.logger.debug(`putRequest to %s with data: %o, config: %o`, fullUrl, data, config);
     return axios.put<Type, HttpRes<Type>>(fullUrl, data, config);
   }
 
   sendDeleteRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`deleteRequest to %s with config: %s`, fullUrl, JSON.stringify(config));
+    this.logger.debug(`deleteRequest to %s with config: %o`, fullUrl, config);
     return axios.delete<Type, HttpRes<Type>>(fullUrl, config);
   }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
객체를 문자열로 출력하기 위해서는 placeholder를 %o로 쓰면 된다.

## 무엇을 어떻게 변경했나요?
JSON.stringify(obj), %s -> obj, %o
