### PR TITLE
feat: DateUtil.parseUnixTime 구현 (PF-6)

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -275,11 +275,18 @@ describe('DateUtil', () => {
       expect(DateUtil.parseUnixTime('1000000000')).toEqual(new Date('2001-09-09T10:46:40+09:00'));
       expect(DateUtil.parseUnixTime('0')).toEqual(new Date(new Date('1970-01-01T00:00:00Z')));
       expect(DateUtil.parseUnixTime('-1000000000')).toEqual(new Date('1938-04-25T07:13:20+09:00'));
+      expect(DateUtil.parseUnixTime(1000000000)).toEqual(new Date('2001-09-09T10:46:40+09:00'));
+      expect(DateUtil.parseUnixTime(0)).toEqual(new Date(new Date('1970-01-01T00:00:00Z')));
+      expect(DateUtil.parseUnixTime(-1000000000)).toEqual(new Date('1938-04-25T07:13:20+09:00'));
     });
 
     it('should throw with invalid parameter', () => {
       expect(() => DateUtil.parseUnixTime(Number.NEGATIVE_INFINITY)).toThrow();
       expect(() => DateUtil.parseUnixTime(Number.POSITIVE_INFINITY)).toThrow();
+      expect(() => DateUtil.parseUnixTime(Number.MAX_SAFE_INTEGER)).toThrow();
+      expect(() => DateUtil.parseUnixTime(Number.MIN_SAFE_INTEGER)).toThrow();
+      expect(() => DateUtil.parseUnixTime(8640000000001)).toThrow();
+      expect(() => DateUtil.parseUnixTime(-8640000000001)).toThrow();
       expect(() => DateUtil.parseUnixTime('')).toThrow();
     });
   });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -269,6 +269,21 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('parseUnixTime', () => {
+    it('should return Date instance of given unix time', () => {
+      // see https://www.epochconverter.com/
+      expect(DateUtil.parseUnixTime('1000000000')).toEqual(new Date('2001-09-09T10:46:40+09:00'));
+      expect(DateUtil.parseUnixTime('0')).toEqual(new Date(new Date('1970-01-01T00:00:00Z')));
+      expect(DateUtil.parseUnixTime('-1000000000')).toEqual(new Date('1938-04-25T07:13:20+09:00'));
+    });
+
+    it('should throw with invalid parameter', () => {
+      expect(() => DateUtil.parseUnixTime(Number.NEGATIVE_INFINITY)).toThrow();
+      expect(() => DateUtil.parseUnixTime(Number.POSITIVE_INFINITY)).toThrow();
+      expect(() => DateUtil.parseUnixTime('')).toThrow();
+    });
+  });
+
   describe('setUTCOffset', () => {
     const testDate1 = '2020-01-01 01:01:01Z';
     const testDate2 = '2020-01-01 00:00:00-09:00';

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -212,8 +212,14 @@ export namespace DateUtil {
   }
 
   export function parseUnixTime(unixTime: string | number): Date {
+    const MAX_SECOND = 8640000000000;
+    const MIN_SECOND = -8640000000000;
+
     if (typeof unixTime === 'string') {
       unixTime = parseInt(unixTime);
+    }
+    if (unixTime > MAX_SECOND || unixTime < MIN_SECOND) {
+      throw new Error(`"${unixTime}" exceeds range of possible date value`);
     }
     unixTime *= ONE_SECOND;
     return parse(unixTime);

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -211,6 +211,14 @@ export namespace DateUtil {
     return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
   }
 
+  export function parseUnixTime(unixTime: string | number): Date {
+    if (typeof unixTime === 'string') {
+      unixTime = parseInt(unixTime);
+    }
+    unixTime *= ONE_SECOND;
+    return parse(unixTime);
+  }
+
   export function setUTCOffset(d: DateType, offsetMinute: number): Date {
     return new Date(parse(d).getTime() + offsetMinute * ONE_SECOND * ONE_MINUTE_IN_SECOND);
   }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://fastcampus.atlassian.net/jira/software/projects/PF/boards/72?selectedIssue=PF-25

## 무엇을 어떻게 변경했나요?
parseByUnix를 ts로 rewriting합니다.
(moment 의존성 제거로 Moment 객체가 아닌 Date를 반환하도록 수정되었습니다.)

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="386" alt="Screen Shot 2022-01-07 at 11 07 52 AM" src="https://user-images.githubusercontent.com/63729090/148479833-bcb11574-00f7-486b-b4e8-6c974baacc6e.png">

