### PR TITLE
merge() 구현 및 deepClone()에서 symbol type 키가 동작하도록 수정

### DIFF
--- a/src/misc-util/misc-util.spec.ts
+++ b/src/misc-util/misc-util.spec.ts
@@ -8,7 +8,7 @@ describe('Miscellaneous Util', () => {
       await MiscUtil.sleep(500);
       const finishTime = Date.now();
       console.timeEnd('sleep');
-      expect(finishTime - startTime).toBeLessThan(500 + 10);
+      expect(finishTime - startTime).toBeLessThan(500 + 15);
       expect(finishTime - startTime).toBeGreaterThanOrEqual(500);
     });
   });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -135,4 +135,21 @@ describe('ObjectUtil', () => {
       expect(() => ObjectUtil.deepClone<Buffer>(buffer)).toThrow();
     });
   });
+
+  describe('merge', () => {
+    it('merge distinct keys', () => {
+      expect(ObjectUtil.merge({ foo: 'abc' }, { bar: 'def' })).toEqual({ foo: 'abc', bar: 'def' });
+    });
+    it('merge same key', () => {
+      expect(ObjectUtil.merge({ foo: 'abc' }, { foo: 'def' })).toEqual({ foo: 'def' });
+    });
+    it('merge three objects', () => {
+      expect(ObjectUtil.merge({ foo: 'abc' }, { bar: 'def' }, { baz: 'ghi' })).toEqual({
+        foo: 'abc',
+        bar: 'def',
+        baz: 'ghi',
+      });
+      expect(ObjectUtil.merge({ foo: 'abc' }, { foo: 'def' }, { foo: 'ghi' })).toEqual({ foo: 'ghi' });
+    });
+  });
 });

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -1,4 +1,5 @@
 import { ObjectUtil } from './object-util';
+import { ObjectType } from './object-util.type';
 
 describe('ObjectUtil', () => {
   describe('serialize', () => {
@@ -129,6 +130,14 @@ describe('ObjectUtil', () => {
       expect(clonedSet instanceof Set).toBe(true);
       expect(clonedSet).not.toBe(set);
       expect(clonedSet).toEqual(set);
+
+      type SymbolKeyObj = { [key: symbol]: string };
+      const symbolKeyObj: SymbolKeyObj = {};
+      const symbol = Symbol('foo');
+      symbolKeyObj[symbol] = 'bar';
+      const clonedSymbolKey = ObjectUtil.deepClone<SymbolKeyObj>(symbolKeyObj);
+      expect(clonedSymbolKey).not.toBe(symbolKeyObj);
+      expect(clonedSymbolKey).toEqual(symbolKeyObj);
     });
     it('should throw error', () => {
       const buffer = Buffer.alloc(10);
@@ -137,19 +146,21 @@ describe('ObjectUtil', () => {
   });
 
   describe('merge', () => {
-    it('merge distinct keys', () => {
-      expect(ObjectUtil.merge({ foo: 'abc' }, { bar: 'def' })).toEqual({ foo: 'abc', bar: 'def' });
-    });
-    it('merge same key', () => {
-      expect(ObjectUtil.merge({ foo: 'abc' }, { foo: 'def' })).toEqual({ foo: 'def' });
-    });
-    it('merge three objects', () => {
-      expect(ObjectUtil.merge({ foo: 'abc' }, { bar: 'def' }, { baz: 'ghi' })).toEqual({
-        foo: 'abc',
-        bar: 'def',
-        baz: 'ghi',
-      });
-      expect(ObjectUtil.merge({ foo: 'abc' }, { foo: 'def' }, { foo: 'ghi' })).toEqual({ foo: 'ghi' });
+    it('merge jsons and arrays', () => {
+      const obj1 = { foo: [{ bar: 2 }, { qux: 4 }] };
+      const obj2 = { foo: [{ baz: 3 }, { quux: 5 }] };
+      type SymbolKeyObj = { [key: symbol]: number };
+      const obj3: SymbolKeyObj = {};
+      const symbol = Symbol('quuz');
+      obj3[symbol] = 6;
+      const result: ObjectType = {
+        foo: [
+          { bar: 2, baz: 3 },
+          { qux: 4, quux: 5 },
+        ],
+      };
+      result[symbol] = 6;
+      expect(ObjectUtil.merge(obj1, obj2, obj3)).toEqual(result);
     });
   });
 });

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -66,4 +66,26 @@ export namespace ObjectUtil {
 
     return clonedObj;
   }
+
+  export function merge(obj: Record<string, unknown>, ...args: Record<string, unknown>[]): Record<string, unknown> {
+    const objKeys = Object.keys(obj);
+    const argKeysArray: string[][] = [];
+    const result: Record<string, unknown> = {};
+
+    args.forEach((arg) => {
+      argKeysArray.push(Object.keys(arg));
+    });
+
+    objKeys.forEach((key) => {
+      result[key] = obj[key];
+    });
+
+    for (let ix = 0; ix < args.length; ix++) {
+      argKeysArray[ix].forEach((key) => {
+        result[key] = args[ix][key];
+      });
+    }
+
+    return result;
+  }
 }

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -57,21 +57,19 @@ export namespace ObjectUtil {
     const keys: (number | string | symbol)[] = Object.getOwnPropertyNames(obj);
     keys.push(...Object.getOwnPropertySymbols(obj));
     keys.forEach((key) => {
+      let value;
       if (obj[key] instanceof Object) {
-        Object.defineProperty(clonedObj, key, {
-          configurable: true,
-          enumerable: true,
-          value: deepClone(obj[key]),
-          writable: true,
-        });
+        value = deepClone(obj[key]);
       } else {
-        Object.defineProperty(clonedObj, key, {
-          configurable: true,
-          enumerable: true,
-          value: obj[key],
-          writable: true,
-        });
+        value = obj[key];
       }
+
+      Object.defineProperty(clonedObj, key, {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
     });
 
     return clonedObj;

--- a/src/object-util/object-util.type.ts
+++ b/src/object-util/object-util.type.ts
@@ -1,1 +1,2 @@
-export type ObjectType = Record<any, any>;
+// export type ObjectType = Record<number | string | symbol, any>;
+export type ObjectType = Record<number | string | symbol, any>;

--- a/src/object-util/object-util.type.ts
+++ b/src/object-util/object-util.type.ts
@@ -1,1 +1,2 @@
-export type ObjectType = Record<number | string | symbol, any>;
+export type ObjectKeyType = number | string | symbol;
+export type ObjectType = Record<ObjectKeyType, any>;

--- a/src/object-util/object-util.type.ts
+++ b/src/object-util/object-util.type.ts
@@ -1,2 +1,1 @@
-// export type ObjectType = Record<number | string | symbol, any>;
 export type ObjectType = Record<number | string | symbol, any>;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
merge() 구현
deepClone()에서 키가 symbol type인 경우 무시되는 현상 수정

## 무엇을 어떻게 변경했나요?
키의 타입에 무관하게 동작하기 위해서 Object.getOwnPropertyNames와 Object.getOwnPropertySymbols 사용
clonedObj[key]가 undefined일 때도 동작하기 위해서 Object.defineProperty를 이용해서 할당

## 어떻게 테스트 하셨나요?
npm run test
