### PR TITLE
feat: DateUtil.format 정규표현식 수정 + formatDate, formatDatetime, formatTimestamp 구현

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -377,6 +377,75 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('formatDate', () => {
+    it('should format date to YYYY-MM-DD format string', () => {
+      expect(DateUtil.formatDate(new Date('2020-01-01 01:01:01:111'))).toBe('2020-01-01');
+      expect(DateUtil.formatDate(new Date('2020-11-11 23:23:23:999'))).toBe('2020-11-11');
+    });
+    it('should format date to YYYY-MM-DD as UTC timezone', () => {
+      const localRuntimeTimezone = new Date().getTimezoneOffset() / 60;
+      const test1 = DateUtil.formatDate(new Date('2020-01-01 01:01:01:111'), true);
+      const test2 = DateUtil.formatDate(new Date('2020-01-01 01:01:01:111Z'), true);
+      const test3 = DateUtil.formatDate(new Date('2020-11-11 23:23:23:999'), true);
+      const test4 = DateUtil.formatDate(new Date('2020-11-11 23:23:23:999Z'), true);
+
+      if (localRuntimeTimezone < 0) {
+        expect(test1).toBe('2019-12-31');
+        expect(test2).toBe('2020-01-01');
+        expect(test3).toBe('2020-11-11');
+        expect(test4).toBe('2020-11-11');
+      }
+      if (localRuntimeTimezone > 0) {
+        expect(test1).toBe('2020-01-01');
+        expect(test2).toBe('2020-01-01');
+        expect(test3).toBe('2020-11-12');
+        expect(test4).toBe('2020-11-11');
+      }
+    });
+  });
+
+  describe('formatDatetime', () => {
+    it('should format date to YYYY-MM-DD HH:mm:ss format string', () => {
+      expect(DateUtil.formatDatetime(new Date('2020-01-01 01:01:01:111'))).toBe('2020-01-01 01:01:01');
+      expect(DateUtil.formatDatetime(new Date('2020-11-11 23:23:23:999'))).toBe('2020-11-11 23:23:23');
+    });
+    it('should format date in local runtime as default', () => {
+      const localRuntimeTimezone = new Date().getTimezoneOffset() / 60;
+      if (localRuntimeTimezone !== 0) {
+        expect(DateUtil.formatDatetime(new Date('2020-01-01 01:01:01:111Z'))).not.toBe('2020-01-01 01:01:01');
+        expect(DateUtil.formatDatetime(new Date('2020-11-11 23:23:23:999Z'))).not.toBe('2020-11-12 23:23:23');
+      } else {
+        expect(DateUtil.formatDatetime(new Date('2020-01-01 01:01:01:111Z'))).toBe('2020-01-01 01:01:01');
+        expect(DateUtil.formatDatetime(new Date('2020-11-11 23:23:23:999Z'))).toBe('2020-11-11 23:23:23');
+      }
+    });
+    it('should format date to YYYY-MM-DD HH:mm:ss as UTC timezone if true value is provided as isUTC parameter', () => {
+      expect(DateUtil.formatDatetime(new Date('2020-01-01 01:01:01:111Z'), true)).toBe('2020-01-01 01:01:01');
+      expect(DateUtil.formatDatetime(new Date('2020-11-11 23:23:23:999Z'), true)).toBe('2020-11-11 23:23:23');
+    });
+  });
+
+  describe('formatTimestamp', () => {
+    it('should format date to YYYYMMDDHHmmssSSS format string', () => {
+      expect(DateUtil.formatTimestamp(new Date('2020-01-01 01:01:01:111'))).toBe('20200101010101111');
+      expect(DateUtil.formatTimestamp(new Date('2020-11-11 23:23:23:999'))).toBe('20201111232323999');
+    });
+    it('should format date in local runtime as default', () => {
+      const localRuntimeTimezone = new Date().getTimezoneOffset() / 60;
+      if (localRuntimeTimezone !== 0) {
+        expect(DateUtil.formatTimestamp(new Date('2020-01-01 01:01:01:111Z'))).not.toBe('20200101010101111');
+        expect(DateUtil.formatTimestamp(new Date('2020-11-11 23:23:23:999Z'))).not.toBe('20201112232323999');
+      } else {
+        expect(DateUtil.formatTimestamp(new Date('2020-01-01 01:01:01:111Z'))).toBe('20200101010101111');
+        expect(DateUtil.formatTimestamp(new Date('2020-11-11 23:23:23:999Z'))).toBe('20201111232323999');
+      }
+    });
+    it('should format date to YYYYMMDDHHmmssSSS as UTC timezone if true value is provided as isUTC parameter', () => {
+      expect(DateUtil.formatTimestamp(new Date('2020-01-01 01:01:01:111Z'), true)).toBe('20200101010101111');
+      expect(DateUtil.formatTimestamp(new Date('2020-11-11 23:23:23:999Z'), true)).toBe('20201111232323999');
+    });
+  });
+
   describe('secondsToTimeFormat', () => {
     it('음수를 넣으면 throw가 발생한다', () => {
       expect(() => DateUtil.secondsToTimeFormat(-5)).toThrow();

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -306,6 +306,7 @@ describe('DateUtil', () => {
       expect(DateUtil.format(testDate1, { format: 'M/D' })).toEqual('1/1');
       expect(DateUtil.format(testDate1, { format: 'MM월 DD일' })).toEqual('01월 01일');
       expect(DateUtil.format(testDate1, { format: 'YY/MM/DD' })).toEqual('20/01/01');
+      expect(DateUtil.format(testDate1, { format: 'YYYYMMDDHHmmssSSS' })).toEqual('20200101010101111');
 
       const testDate2 = new Date('2020-11-11 23:23:23:999');
       expect(DateUtil.format(testDate2, { format: 'YYYY-MM-DD HH:mm:ss' })).toEqual('2020-11-11 23:23:23');
@@ -317,6 +318,7 @@ describe('DateUtil', () => {
       expect(DateUtil.format(testDate2, { format: 'M/D' })).toEqual('11/11');
       expect(DateUtil.format(testDate2, { format: 'MM월 DD일' })).toEqual('11월 11일');
       expect(DateUtil.format(testDate2, { format: 'YY/MM/DD' })).toEqual('20/11/11');
+      expect(DateUtil.format(testDate2, { format: 'YYYYMMDDHHmmssSSS' })).toEqual('20201111232323999');
     });
 
     it('should format date to string with default format rule', () => {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -10,6 +10,9 @@ const ONE_MINUTE_IN_SECOND = 60;
 const DEFAULT_UTC_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 const DEFAULT_LOCALE_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss[Z]';
 const DEFAULT_LOCALE_TIMEZONE_FORMAT = '[Z]';
+const DATE_FORMAT = 'YYYY-MM-DD';
+const DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+const TIMESTAMP_FORMAT = 'YYYYMMDDHHmmssSSS';
 
 const logger = LoggerFactory.getLogger('pebbles:date-util');
 
@@ -208,7 +211,7 @@ export namespace DateUtil {
   }
 
   export function parseTimestamp(str: string): Date {
-    return parseByFormat(str, 'YYYYMMDDHHmmssSSS');
+    return parseByFormat(str, TIMESTAMP_FORMAT);
   }
 
   export function setUTCOffset(d: DateType, offsetMinute: number): Date {
@@ -302,6 +305,16 @@ export namespace DateUtil {
     const ISOFormat = opts.format;
     const isUTC = opts.isUTC ?? false;
     return format(d, { format: ISOFormat, isUTC: isUTC });
+  }
+
+  export function formatDate(d: Date, isUTC = false): string {
+    return format(d, { format: DATE_FORMAT, isUTC });
+  }
+  export function formatDatetime(d: Date, isUTC = false): string {
+    return format(d, { format: DATETIME_FORMAT, isUTC });
+  }
+  export function formatTimestamp(d: Date, isUTC = false): string {
+    return format(d, { format: TIMESTAMP_FORMAT, isUTC });
   }
 
   export function secondsToTimeFormat(seconds: number): string {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -244,7 +244,8 @@ export namespace DateUtil {
       formatTarget = formatTarget.replace(DEFAULT_LOCALE_TIMEZONE_FORMAT, getLocaleTimezoneOffset(d));
     }
 
-    const FORMAT_RULE_REGEXP = /[yYmMdDhHsS]{1,4}/g;
+    const FORMAT_RULE_REGEXP = /(Y{2,4}|M?M|D?D|H?H|m?m|s?s|S?S?S)/g;
+    const FORMAT_VERIFICATION_REGEXP = /(Y{2,4}|M?M|D?D|H?H|S?S?S)/gi;
     formatTarget = formatTarget.replace(FORMAT_RULE_REGEXP, (match) => {
       switch (match) {
         case 'YYYY':
@@ -288,7 +289,7 @@ export namespace DateUtil {
           return match;
       }
     });
-    if (FORMAT_RULE_REGEXP.test(formatTarget)) {
+    if (FORMAT_VERIFICATION_REGEXP.test(formatTarget)) {
       throw new Error(`Invalid format: ${formatTarget}`);
     }
     return formatTarget;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?
- format 함수 테스트 도중 `FORMAT_RULE_REGEXP` 정규표현식이 `YYYYMMDDHHmmssSSS` 포맷을 제대로 매치시키지 못하는 에러를 발견하여 수정하였습니다.
- Invalid format인지 테스트하는 부분에서는 
```javascript
    if (FORMAT_RULE_REGEXP.test(formatTarget)) {
      throw new Error(`Invalid format: ${formatTarget}`);
    }
```

기존 스펙에 맞추기 위해 `FORMAT_VERIFICATION_REGEXP` 정규표현식을 별도로 선언하여 사용합니다.
- format의 테스트코드를 추가했습니다.

---

- `formatDate`, `formatDatetime`, `formatTimestamp` 를 추가합니다.
- 기존 redstone/util 스펙과 동일하게, format 함수들의 기본 결과물은 로컬 런타임을 따르도록 하였습니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="572" alt="Screen Shot 2022-01-10 at 4 43 24 PM" src="https://user-images.githubusercontent.com/63729090/148732260-6c4aeff9-86be-4f49-82d2-4d15edc97a92.png">

