### PR TITLE
feat: DateUtil의 parseByUtc 기능 추가

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -276,10 +276,15 @@ describe('DateUtil', () => {
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00Z')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));
-      // Date 객체 자체에서 UTC 여부를 알 수 없으므로 변환
-      expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).not.toEqual(new Date('2022-01-01T00:00:00Z'));
       const now = new Date();
-      expect(DateUtil.parseByUtc(now)).not.toEqual(now);
+      if (new Date().getTimezoneOffset() === 0) {
+        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).toEqual(new Date('2022-01-01T00:00:00Z'));
+        expect(DateUtil.parseByUtc(now)).toEqual(now);
+      } else {
+        // Date 객체 자체에서 UTC 여부를 알 수 없으므로 변환
+        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).not.toEqual(new Date('2022-01-01T00:00:00Z'));
+        expect(DateUtil.parseByUtc(now)).not.toEqual(now);
+      }
     });
   });
 

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -276,15 +276,12 @@ describe('DateUtil', () => {
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00Z')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00+09:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
-      expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));
-      const now = new Date();
+      expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).toEqual(new Date('2022-01-01T00:00:00Z'));
       if (new Date().getTimezoneOffset() === 0) {
-        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).toEqual(new Date('2022-01-01T00:00:00Z'));
-        expect(DateUtil.parseByUtc(now)).toEqual(now);
+        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));
       } else {
         // Date 객체 자체에서 UTC 여부를 알 수 없으므로 변환
-        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).not.toEqual(new Date('2022-01-01T00:00:00Z'));
-        expect(DateUtil.parseByUtc(now)).not.toEqual(now);
+        expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).not.toEqual(new Date('2022-01-01T00:00:00Z'));
       }
     });
   });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -264,6 +264,25 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('parseByUtc', () => {
+    it('should throw error when invalid arguments given', () => {
+      expect(() => DateUtil.parseByUtc('')).toThrow();
+      expect(() => DateUtil.parseByUtc('abc')).toThrow();
+      expect(() => DateUtil.parseByUtc('1월 1일')).toThrow();
+    });
+
+    it('should return converted date UTC', () => {
+      expect(DateUtil.parseByUtc('2021-12-31')).toEqual(new Date('2021-12-31T00:00:00Z'));
+      expect(DateUtil.parseByUtc('2022-01-01 00:00:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
+      expect(DateUtil.parseByUtc('2022-01-01 00:00:00Z')).toEqual(new Date('2022-01-01T00:00:00Z'));
+      expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));
+      // Date 객체 자체에서 UTC 여부를 알 수 없으므로 변환
+      expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).not.toEqual(new Date('2022-01-01T00:00:00Z'));
+      const now = new Date();
+      expect(DateUtil.parseByUtc(now)).not.toEqual(now);
+    });
+  });
+
   describe('parseTimestamp', () => {
     it('should throw error when invalid arguments given', () => {
       expect(() => DateUtil.parseTimestamp('20210131')).not.toThrow();

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -275,6 +275,7 @@ describe('DateUtil', () => {
       expect(DateUtil.parseByUtc('2021-12-31')).toEqual(new Date('2021-12-31T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00Z')).toEqual(new Date('2022-01-01T00:00:00Z'));
+      expect(DateUtil.parseByUtc('2022-01-01 00:00:00+09:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));
       const now = new Date();
       if (new Date().getTimezoneOffset() === 0) {

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -275,7 +275,7 @@ describe('DateUtil', () => {
       expect(DateUtil.parseByUtc('2021-12-31')).toEqual(new Date('2021-12-31T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
       expect(DateUtil.parseByUtc('2022-01-01 00:00:00Z')).toEqual(new Date('2022-01-01T00:00:00Z'));
-      expect(DateUtil.parseByUtc('2022-01-01 00:00:00+09:00')).toEqual(new Date('2022-01-01T00:00:00Z'));
+      expect(DateUtil.parseByUtc('2022-01-01 00:00:00+09:00')).toEqual(new Date('2021-12-31T15:00:00Z'));
       expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00Z'))).toEqual(new Date('2022-01-01T00:00:00Z'));
       if (new Date().getTimezoneOffset() === 0) {
         expect(DateUtil.parseByUtc(new Date('2022-01-01 00:00:00'))).toEqual(new Date('2022-01-01T00:00:00Z'));

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -226,9 +226,7 @@ export namespace DateUtil {
   }
 
   export function parseByUtc(d: DateType): Date {
-    if (d instanceof Date) {
-      d = d.getTime() - d.getTimezoneOffset() * ONE_SECOND * ONE_MINUTE_IN_SECOND;
-    } else if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
+    if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
       d = d + 'Z';
     }
     return parse(d);

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -225,6 +225,16 @@ export namespace DateUtil {
     return new Date(parse(d).getTime() + offsetMinute * ONE_SECOND_IN_MILLI * ONE_MINUTE_IN_SECOND);
   }
 
+  export function parseByUtc(d: DateType): Date {
+    if (d instanceof Date) {
+      return parse(d.getTime() - d.getTimezoneOffset() * 60 * 1000);
+    }
+    if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
+      d = d + 'Z';
+    }
+    return parse(d);
+  }
+
   export function format(d: Date, opts?: DateFormatOpts): string {
     // format의 기본 기준은 로컬 런타임으로 한다.
     const isUTC = opts?.isUTC ?? false;

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -226,7 +226,7 @@ export namespace DateUtil {
   }
 
   export function parseByUtc(d: DateType): Date {
-    if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
+    if (typeof d === 'string' && !/UTC|GMT|Z|z|[+-]\d\d(:?\d\d)$/.test(d)) {
       d = d + 'Z';
     }
     return parse(d);

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -227,9 +227,8 @@ export namespace DateUtil {
 
   export function parseByUtc(d: DateType): Date {
     if (d instanceof Date) {
-      return parse(d.getTime() - d.getTimezoneOffset() * 60 * 1000);
-    }
-    if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
+      d = d.getTime() - d.getTimezoneOffset() * ONE_SECOND * ONE_MINUTE_IN_SECOND;
+    } else if (typeof d === 'string' && !/UTC|GMT|Z|z$/.test(d)) {
       d = d + 'Z';
     }
     return parse(d);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
moment.js의 utc()를 대체하는 parseByUtc 추가

## 무엇을 어떻게 변경했나요?
parseByUtc: moment.utc 변환기능대응. date객체로 prase

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
~Date getTimezoneOffset()을 사용하여 offset 보정하는 방식으로 UTC변환하였지만, 서머타임을 적용하는 지역이나 여러 이유로 오차가 발생될 여지가 있습니다.~
확인해보니 현재 기능엔 불필요한 작업으로 판단되어 삭제


