### PR TITLE
fix: ObjectUtil.omit의 버그 수정

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -217,5 +217,28 @@ describe('ObjectUtil', () => {
       expect(ObjectUtil.omit(testObj1, [symbol1])).toEqual({ [symbol2]: 2 });
       expect(ObjectUtil.omit(testObj2, [1])).toEqual({ [2]: 2 });
     });
+
+    it('should skip with key which does not exist', () => {
+      const testObj1 = { foo: 1, bar: 2 };
+      const testObj2 = { foo: 1, bar: { foo: 1, bar: { foo: 1, bar: 2 } } };
+      const testObj3 = { [Symbol('foo')]: 1 };
+      const testObj4 = { [1]: 1, [2]: 2 };
+      expect(ObjectUtil.omit(testObj1, ['bar.foo.bar'])).toEqual(testObj1);
+      expect(ObjectUtil.omit(testObj2, ['bar.bar', 'bar.bar'])).toEqual({ foo: 1, bar: { foo: 1 } });
+      expect(ObjectUtil.omit(testObj3, [Symbol('bar')])).toEqual(testObj3);
+      expect(ObjectUtil.omit(testObj4, [3])).toEqual(testObj4);
+    });
+
+    it('should return obj as a new object when one of two parameters is empty', () => {
+      const testObj1 = {};
+      const testObj2 = new Map();
+      const testObj3 = new Set();
+      expect(ObjectUtil.omit(testObj1, ['foo'])).toEqual({});
+      expect(ObjectUtil.omit(testObj1, ['foo'])).not.toBe(testObj1);
+      expect(ObjectUtil.omit(testObj2, ['foo'])).toEqual(new Map());
+      expect(ObjectUtil.omit(testObj2, ['foo'])).not.toBe(testObj2);
+      expect(ObjectUtil.omit(testObj3, ['foo'])).toEqual(new Set());
+      expect(ObjectUtil.omit(testObj3, ['foo'])).not.toBe(testObj3);
+    });
   });
 });

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -96,18 +96,16 @@ export namespace ObjectUtil {
     return result;
   }
 
+  // TODO: array에 대한 처리
   export function omit(obj: ObjectType, omitKeys: ObjectKeyType[]): ObjectType {
     const keys: ObjectKeyType[] = Object.getOwnPropertyNames(obj);
     keys.push(...Object.getOwnPropertySymbols(obj));
 
-    if (keys.length <= 0) {
-      return {};
-    }
-    if (omitKeys.length <= 0) {
-      return obj;
-    }
-
     const resultObj = deepClone(obj);
+
+    if (keys.length <= 0 || omitKeys.length <= 0) {
+      return resultObj;
+    }
 
     for (const key of omitKeys) {
       let tempObj = resultObj;
@@ -116,13 +114,17 @@ export namespace ObjectUtil {
       if (typeof key === 'string') {
         nestedKeys = key.split('.');
       }
-      for (let i = 0; i < nestedKeys.length; i++) {
-        if (i === nestedKeys.length - 1) {
-          delete tempObj[nestedKeys[i]];
-          break;
+      nestedKeys.forEach((tempKey, index) => {
+        if (isNullish(tempObj[tempKey])) {
+          return false;
         }
-        tempObj = tempObj[nestedKeys[i]];
-      }
+        if (index === nestedKeys.length - 1) {
+          delete tempObj[tempKey];
+          return false;
+        }
+        tempObj = tempObj[tempKey];
+        return true;
+      });
     }
     return resultObj;
   }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
1. 존재하지 않는 키가 `omitKeys`의 요소로 들어올 경우 예외처리 안되어 있음
2. `obj` 인자가 빈 객체인 경우 `obj` 인자 형태를 반환하지 않고 {}를 반환함
ex : `omit(new Map(), [1,2]) => return {}` 
3. `obj`나 `omitKeys`가 비었을 경우 기존 `obj`를 그대로 반환 => deepClone된 객체를 반환하는 일반적인 경우와 일관성이 없음

## 무엇을 어떻게 변경했나요?
1. for문 돌면서 현재 key에 대한 value가 null | undefined일 경우 throw
2. `obj`나 `omitKeys`가 비었을 경우 `deepClone(obj)`를 반환하도록 수정
3. 테스트코드 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
