### PR TITLE
feat: DateUtil에 YY/MM/DD (ddd) HH 형식으로 로컬타임을 포맷하는 함수를 추가합니다

### DIFF
--- a/src/date-util/date-util.interface.ts
+++ b/src/date-util/date-util.interface.ts
@@ -11,3 +11,9 @@ export interface DateFormatOpts {
   readonly format?: string;
   readonly isUTC?: boolean;
 }
+
+export interface LocalDateTimeFormatOpts {
+  readonly withYear?: boolean;
+  readonly timeZone: string;
+  readonly locale: string;
+}

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -488,4 +488,44 @@ describe('DateUtil', () => {
       expect(DateUtil.secondsToTimeFormat(100_000)).toEqual('27:46:40'); // 100,000초 => 27시간 46분 40초
     });
   });
+
+  describe('formatInTwoDigitLocalTime', () => {
+    const testDate1 = '2000-01-01 00:00:00+09:00';
+    const testDate2 = '2000-01-01 12:00:00+09:00';
+    const testDate3 = '2000-01-01 12:00:00Z';
+    const testDate4 = new Date(testDate3).getTime();
+
+    it('should format date in two digit with year', () => {
+      const testOption1 = {
+        locale: 'ko',
+        timeZone: 'Asia/Seoul',
+        withYear: true,
+      };
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption1)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption1)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption1)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption1)).toBe('00/01/01 (토) 21시');
+
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption1)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption1)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption1)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption1)).toBe('00/01/01 (토) 21시');
+    });
+
+    it('should format date in two digit without year', () => {
+      const testOption = {
+        locale: 'ko-KR',
+        timeZone: 'Asia/Seoul',
+      };
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption)).toBe('12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption)).toBe('01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption)).toBe('01/01 (토) 21시');
+
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption)).toBe('12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption)).toBe('01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption)).toBe('01/01 (토) 21시');
+    });
+  });
 });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -1,4 +1,5 @@
 import { DateUtil } from './date-util';
+import type { LocalDateTimeFormatOpts } from './date-util.interface';
 
 describe('DateUtil', () => {
   describe('parse', () => {
@@ -496,24 +497,24 @@ describe('DateUtil', () => {
     const testDate4 = new Date(testDate3).getTime();
 
     it('should format date in two digit with year', () => {
-      const testOption1 = {
+      const testOption: LocalDateTimeFormatOpts = {
         locale: 'ko',
         timeZone: 'Asia/Seoul',
         withYear: true,
       };
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption1)).toBe('99/12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption1)).toBe('00/01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption1)).toBe('00/01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption1)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption)).toBe('00/01/01 (토) 21시');
 
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption1)).toBe('99/12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption1)).toBe('00/01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption1)).toBe('00/01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption1)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption)).toBe('00/01/01 (토) 21시');
     });
 
     it('should format date in two digit without year', () => {
-      const testOption = {
+      const testOption: LocalDateTimeFormatOpts = {
         locale: 'ko-KR',
         timeZone: 'Asia/Seoul',
       };

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -1,4 +1,4 @@
-import type { CalcDatetimeOpts, DateFormatOpts } from './date-util.interface';
+import type { CalcDatetimeOpts, DateFormatOpts, LocalDateTimeFormatOpts } from './date-util.interface';
 import type { DateType, DatePropertyType, ISO8601FormatType } from './date-util.type';
 import { LoggerFactory } from '../logger';
 
@@ -344,6 +344,61 @@ export namespace DateUtil {
       .padStart(2, '0');
     const ss = (seconds % 60).toString().padStart(2, '0');
     return `${hh}:${mm}:${ss}`;
+  }
+
+  export function formatInTwoDigitLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
+    d = subtractDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
+
+    const options: Intl.DateTimeFormatOptions = {
+      year: opts.withYear ? '2-digit' : undefined,
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      weekday: 'short',
+      hour12: false,
+      timeZone: opts.timeZone,
+    };
+
+    let formatResult = new Intl.DateTimeFormat(opts.locale, options).format(d);
+
+    formatResult = formatResult.replace(/[.]\s(?=.*[.])|[.]/g, (match) => {
+      switch (match) {
+        case '. ':
+          return '/';
+        case '.':
+          return '';
+        default:
+          return match;
+      }
+    });
+    return format12HourInLocale(formatResult, opts.locale);
+  }
+}
+
+function subtractDayIfLocalTimeIsMidnight(d: Date, timeZone: string) {
+  const isMidnight =
+    new Intl.DateTimeFormat('default', { hour: '2-digit', hour12: false, timeZone: timeZone }).format(d) === '24';
+  if (isMidnight) {
+    return DateUtil.calcDatetime(d, { date: -1 });
+  }
+  return d;
+}
+
+function format12HourInLocale(str: string, locale: string): string {
+  const INTL_MIDNIGHT_OR_NOON_KOR_REGEXP = /(24시|12시)/g;
+
+  // TODO: 별도 enum으로 관리?
+  const ReplaceMap: { [key: string]: string } = {
+    '24시': '자정',
+    '12시': '정오',
+  };
+
+  switch (locale) {
+    case 'ko-KR':
+    case 'ko':
+      return str.replace(INTL_MIDNIGHT_OR_NOON_KOR_REGEXP, (match) => ReplaceMap[match]);
+    default:
+      return str;
   }
 }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
redstone의 `formatLocalDate`, `formatLocalDateShortcut` 함수의 ts 이관입니다.

## 무엇을 어떻게 변경했나요?
`formatLocalDate`, `formatLocalDateShortcut` 함수를 하나로 합쳤습니다.
년도 표기 유무 차이만 있기 때문에 `opts` 파라미터에 `skipYear` 값으로 분기점을 설정했습니다.

`Intl.DatetimeFormat`을 활용했습니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
기존 스펙
1. YY/MM/DD (ddd) {HH|자정|정오} 결과값을 반환합니다.
2. 24시 표기를 기준으로 합니다.
3. 12시, 24시의 경우 정오, 자정으로 표기합니다.
4. 00시일 경우 전날 자정을 반환합니다 (1월1일00시 -> 12월31일24시)

`Intl.DatetimeFormat`에 ko-KR 로케일 지정시 YYYY. MM. DD. 형식으로 반환되기 때문에 replace문으로 슬래시로 변환했습니다.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="592" alt="Screen Shot 2022-01-18 at 11 54 07 AM" src="https://user-images.githubusercontent.com/63729090/149862721-a70e8567-e1bb-44e2-86a2-a9087d4e19dd.png">

