### PR TITLE
DateUtil.parse()의 불필요한 로직 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@day1co/pebbles",
       "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",
         "mustache": "^4.2.0",

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -2,7 +2,7 @@ import type { CalcDatetimeOpts, DateFormatOpts } from './date-util.interface';
 import type { DateType, DatePropertyType, ISO8601FormatType } from './date-util.type';
 import { LoggerFactory } from '../logger';
 
-const ONE_SECOND = 1000;
+const ONE_SECOND_IN_MILLI = 1000;
 const ONE_DAY_IN_SECOND = 60 * 60 * 24;
 const ONE_HOUR_IN_SECOND = 60 * 60;
 const ONE_MINUTE_IN_SECOND = 60;
@@ -22,16 +22,13 @@ export namespace DateUtil {
   }
 
   export function parse(d: DateType): Date {
-    const originalD = d;
-    if (!(d instanceof Date)) {
-      d = new Date(d);
+    const parsedDate = new Date(d);
+
+    if (!isValidDate(parsedDate)) {
+      throw new Error(`Invalid Date: ${d.toString()}`);
     }
 
-    if (!isValidDate(d)) {
-      throw new Error(`Invalid Date: ${originalD.toString()}`);
-    }
-
-    return new Date(d.getTime());
+    return parsedDate;
   }
 
   export function calcDatetime(d: DateType, opts: CalcDatetimeOpts): Date {
@@ -92,7 +89,7 @@ export namespace DateUtil {
       return -diff(until, since, type);
     }
 
-    const diffSeconds = (untilDate.getTime() - sinceDate.getTime()) / ONE_SECOND;
+    const diffSeconds = (untilDate.getTime() - sinceDate.getTime()) / ONE_SECOND_IN_MILLI;
 
     let result = 0;
     switch (type) {
@@ -228,12 +225,12 @@ export namespace DateUtil {
     if (unixTime > MAX_SECOND || unixTime < MIN_SECOND) {
       throw new Error(`"${unixTime}" exceeds range of possible date value`);
     }
-    unixTime *= ONE_SECOND;
+    unixTime *= ONE_SECOND_IN_MILLI;
     return parse(unixTime);
   }
 
   export function setUTCOffset(d: DateType, offsetMinute: number): Date {
-    return new Date(parse(d).getTime() + offsetMinute * ONE_SECOND * ONE_MINUTE_IN_SECOND);
+    return new Date(parse(d).getTime() + offsetMinute * ONE_SECOND_IN_MILLI * ONE_MINUTE_IN_SECOND);
   }
 
   export function format(d: Date, opts?: DateFormatOpts): string {

--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -33,8 +33,8 @@ describe('NumberUtil', () => {
       expect(NumberUtil.valueOf('0')).toEqual(0);
       expect(NumberUtil.valueOf('1.2')).toEqual(1.2);
       expect(NumberUtil.valueOf('-1.2')).toEqual(-1.2);
-      expect(NumberUtil.valueOf('-93339.228883747849').toString()).toEqual(`-93339.22888374786`);
-      expect(NumberUtil.valueOf('9488848.29000004833').toString()).toEqual(`9488848.290000048`);
+      expect(NumberUtil.valueOf('-93339.228883747849')).toEqual(-93339.22888374786);
+      expect(NumberUtil.valueOf('9488848.29000004833')).toEqual(9488848.290000048);
     });
   });
 });


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
DateUtil.parse()에서 불필요한 new Date()를 하고 있다.

## 무엇을 어떻게 변경했나요?
DateUtil.parse()에서 불필요하게 new Date()를 하는 부분 제거
ONE_SECOND -> ONE_SECOND_IN_MILLI
NumberUtil 테스트의 불필요한 toString()제거

## 어떻게 테스트 하셨나요?
npm run test
