### PR TITLE
feat: 날짜를 로컬 타임존의 long 형식으로 포맷하는 함수 구현 (DCM-43)

### DIFF
--- a/src/date-util/date-util.interface.ts
+++ b/src/date-util/date-util.interface.ts
@@ -24,4 +24,5 @@ export interface LocalDateTimeFormatOpts {
   readonly withYear?: boolean;
   readonly timeZone: string;
   readonly locale: string;
+  readonly formatStyle: 'long' | '2-digit';
 }

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -530,4 +530,36 @@ describe('DateUtil', () => {
       expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption)).toBe('01/01 (토) 21시');
     });
   });
+
+  describe('formatInLongLocalTime', () => {
+    const testDate1 = '2000-01-01 00:00:00+09:00';
+    const testDate2 = '2000-01-01 12:00:00+09:00';
+    const testDate3 = '2000-01-01 12:00:00Z';
+    const testDate4 = new Date(testDate3).getTime();
+
+    it('should format date in long description format without year', () => {
+      const testOption: LocalDateTimeFormatOpts = {
+        locale: 'ko-KR',
+        timeZone: 'Asia/Seoul',
+      };
+
+      expect(DateUtil.formatInLongLocalTime(testDate1, testOption)).toBe('12월 31일 금요일 자정');
+      expect(DateUtil.formatInLongLocalTime(testDate2, testOption)).toBe('1월 1일 토요일 정오');
+      expect(DateUtil.formatInLongLocalTime(testDate3, testOption)).toBe('1월 1일 토요일 21시');
+      expect(DateUtil.formatInLongLocalTime(testDate4, testOption)).toBe('1월 1일 토요일 21시');
+    });
+
+    it('should format date in long description format with year', () => {
+      const testOption: LocalDateTimeFormatOpts = {
+        locale: 'ko-KR',
+        timeZone: 'Asia/Seoul',
+        withYear: true,
+      };
+
+      expect(DateUtil.formatInLongLocalTime(testDate1, testOption)).toBe('1999년 12월 31일 금요일 자정');
+      expect(DateUtil.formatInLongLocalTime(testDate2, testOption)).toBe('2000년 1월 1일 토요일 정오');
+      expect(DateUtil.formatInLongLocalTime(testDate3, testOption)).toBe('2000년 1월 1일 토요일 21시');
+      expect(DateUtil.formatInLongLocalTime(testDate4, testOption)).toBe('2000년 1월 1일 토요일 21시');
+    });
+  });
 });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -491,7 +491,7 @@ describe('DateUtil', () => {
     });
   });
 
-  describe('formatInTwoDigitLocalTime', () => {
+  describe('formatLocalTime', () => {
     const testDate1 = '2000-01-01 00:00:00+09:00';
     const testDate2 = '2000-01-01 12:00:00+09:00';
     const testDate3 = '2000-01-01 12:00:00Z';
@@ -501,52 +501,48 @@ describe('DateUtil', () => {
       const testOption: LocalDateTimeFormatOpts = {
         locale: 'ko',
         timeZone: 'Asia/Seoul',
+        formatStyle: '2-digit',
         withYear: true,
       };
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption)).toBe('99/12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption)).toBe('00/01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption)).toBe('00/01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(testDate1, testOption)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatLocalTime(testDate2, testOption)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatLocalTime(testDate3, testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(testDate4, testOption)).toBe('00/01/01 (토) 21시');
 
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption)).toBe('99/12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption)).toBe('00/01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption)).toBe('00/01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(new Date(testDate1), testOption)).toBe('99/12/31 (금) 자정');
+      expect(DateUtil.formatLocalTime(new Date(testDate2), testOption)).toBe('00/01/01 (토) 정오');
+      expect(DateUtil.formatLocalTime(new Date(testDate3), testOption)).toBe('00/01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(new Date(testDate4), testOption)).toBe('00/01/01 (토) 21시');
     });
 
     it('should format date in two digit without year', () => {
       const testOption: LocalDateTimeFormatOpts = {
         locale: 'ko-KR',
         timeZone: 'Asia/Seoul',
+        formatStyle: '2-digit',
       };
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate1, testOption)).toBe('12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate2, testOption)).toBe('01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate3, testOption)).toBe('01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(testDate4, testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(testDate1, testOption)).toBe('12/31 (금) 자정');
+      expect(DateUtil.formatLocalTime(testDate2, testOption)).toBe('01/01 (토) 정오');
+      expect(DateUtil.formatLocalTime(testDate3, testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(testDate4, testOption)).toBe('01/01 (토) 21시');
 
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate1), testOption)).toBe('12/31 (금) 자정');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate2), testOption)).toBe('01/01 (토) 정오');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate3), testOption)).toBe('01/01 (토) 21시');
-      expect(DateUtil.formatInTwoDigitLocalTime(new Date(testDate4), testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(new Date(testDate1), testOption)).toBe('12/31 (금) 자정');
+      expect(DateUtil.formatLocalTime(new Date(testDate2), testOption)).toBe('01/01 (토) 정오');
+      expect(DateUtil.formatLocalTime(new Date(testDate3), testOption)).toBe('01/01 (토) 21시');
+      expect(DateUtil.formatLocalTime(new Date(testDate4), testOption)).toBe('01/01 (토) 21시');
     });
-  });
-
-  describe('formatInLongLocalTime', () => {
-    const testDate1 = '2000-01-01 00:00:00+09:00';
-    const testDate2 = '2000-01-01 12:00:00+09:00';
-    const testDate3 = '2000-01-01 12:00:00Z';
-    const testDate4 = new Date(testDate3).getTime();
 
     it('should format date in long description format without year', () => {
       const testOption: LocalDateTimeFormatOpts = {
         locale: 'ko-KR',
         timeZone: 'Asia/Seoul',
+        formatStyle: 'long',
       };
 
-      expect(DateUtil.formatInLongLocalTime(testDate1, testOption)).toBe('12월 31일 금요일 자정');
-      expect(DateUtil.formatInLongLocalTime(testDate2, testOption)).toBe('1월 1일 토요일 정오');
-      expect(DateUtil.formatInLongLocalTime(testDate3, testOption)).toBe('1월 1일 토요일 21시');
-      expect(DateUtil.formatInLongLocalTime(testDate4, testOption)).toBe('1월 1일 토요일 21시');
+      expect(DateUtil.formatLocalTime(testDate1, testOption)).toBe('12월 31일 금요일 자정');
+      expect(DateUtil.formatLocalTime(testDate2, testOption)).toBe('1월 1일 토요일 정오');
+      expect(DateUtil.formatLocalTime(testDate3, testOption)).toBe('1월 1일 토요일 21시');
+      expect(DateUtil.formatLocalTime(testDate4, testOption)).toBe('1월 1일 토요일 21시');
     });
 
     it('should format date in long description format with year', () => {
@@ -554,12 +550,13 @@ describe('DateUtil', () => {
         locale: 'ko-KR',
         timeZone: 'Asia/Seoul',
         withYear: true,
+        formatStyle: 'long',
       };
 
-      expect(DateUtil.formatInLongLocalTime(testDate1, testOption)).toBe('1999년 12월 31일 금요일 자정');
-      expect(DateUtil.formatInLongLocalTime(testDate2, testOption)).toBe('2000년 1월 1일 토요일 정오');
-      expect(DateUtil.formatInLongLocalTime(testDate3, testOption)).toBe('2000년 1월 1일 토요일 21시');
-      expect(DateUtil.formatInLongLocalTime(testDate4, testOption)).toBe('2000년 1월 1일 토요일 21시');
+      expect(DateUtil.formatLocalTime(testDate1, testOption)).toBe('1999년 12월 31일 금요일 자정');
+      expect(DateUtil.formatLocalTime(testDate2, testOption)).toBe('2000년 1월 1일 토요일 정오');
+      expect(DateUtil.formatLocalTime(testDate3, testOption)).toBe('2000년 1월 1일 토요일 21시');
+      expect(DateUtil.formatLocalTime(testDate4, testOption)).toBe('2000년 1월 1일 토요일 21시');
     });
   });
 });

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -345,7 +345,7 @@ export namespace DateUtil {
   }
 
   export function formatInTwoDigitLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
-    d = subtractDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
+    d = subtractOneDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
 
     const options: Intl.DateTimeFormatOptions = {
       year: opts.withYear ? '2-digit' : undefined,
@@ -371,9 +371,26 @@ export namespace DateUtil {
     });
     return format12HourInLocale(formatResult, opts.locale);
   }
+
+  export function formatInLongLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
+    d = subtractOneDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
+
+    const options: Intl.DateTimeFormatOptions = {
+      year: opts.withYear ? 'numeric' : undefined,
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      weekday: 'long',
+      hour12: false,
+      timeZone: opts.timeZone,
+    };
+
+    const formatResult = new Intl.DateTimeFormat(opts.locale, options).format(d);
+    return format12HourInLocale(formatResult, opts.locale);
+  }
 }
 
-function subtractDayIfLocalTimeIsMidnight(d: Date, timeZone: string): Date {
+function subtractOneDayIfLocalTimeIsMidnight(d: Date, timeZone: string): Date {
   const isMidnight =
     new Intl.DateTimeFormat('en-US', { hour: '2-digit', hour12: false, timeZone: timeZone }).format(d) === '24';
   if (isMidnight) {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -344,21 +344,37 @@ export namespace DateUtil {
     return `${hh}:${mm}:${ss}`;
   }
 
-  export function formatInTwoDigitLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
+  export function formatLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
     d = subtractOneDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
+    let options: Intl.DateTimeFormatOptions;
 
-    const options: Intl.DateTimeFormatOptions = {
-      year: opts.withYear ? '2-digit' : undefined,
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      weekday: 'short',
-      hour12: false,
-      timeZone: opts.timeZone,
-    };
+    switch (opts.formatStyle) {
+      case '2-digit':
+        options = {
+          year: opts.withYear ? '2-digit' : undefined,
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          weekday: 'short',
+          hour12: false,
+          timeZone: opts.timeZone,
+        };
+        break;
+
+      case 'long':
+        options = {
+          year: opts.withYear ? 'numeric' : undefined,
+          month: 'long',
+          day: 'numeric',
+          hour: '2-digit',
+          weekday: 'long',
+          hour12: false,
+          timeZone: opts.timeZone,
+        };
+        break;
+    }
 
     let formatResult = new Intl.DateTimeFormat(opts.locale, options).format(d);
-
     formatResult = formatResult.replace(/[.]\s(?=.*[.])|[.]/g, (match) => {
       switch (match) {
         case '. ':
@@ -369,23 +385,6 @@ export namespace DateUtil {
           return match;
       }
     });
-    return format12HourInLocale(formatResult, opts.locale);
-  }
-
-  export function formatInLongLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
-    d = subtractOneDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
-
-    const options: Intl.DateTimeFormatOptions = {
-      year: opts.withYear ? 'numeric' : undefined,
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      weekday: 'long',
-      hour12: false,
-      timeZone: opts.timeZone,
-    };
-
-    const formatResult = new Intl.DateTimeFormat(opts.locale, options).format(d);
     return format12HourInLocale(formatResult, opts.locale);
   }
 }

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -346,45 +346,42 @@ export namespace DateUtil {
 
   export function formatLocalTime(d: DateType, opts: LocalDateTimeFormatOpts): string {
     d = subtractOneDayIfLocalTimeIsMidnight(parse(d), opts.timeZone);
-    let options: Intl.DateTimeFormatOptions;
 
+    const options: Intl.DateTimeFormatOptions = {};
     switch (opts.formatStyle) {
       case '2-digit':
-        options = {
-          year: opts.withYear ? '2-digit' : undefined,
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          weekday: 'short',
-          hour12: false,
-          timeZone: opts.timeZone,
-        };
+        options.year = opts.withYear ? '2-digit' : undefined;
+        options.month = '2-digit';
+        options.day = '2-digit';
+        options.hour = '2-digit';
+        options.weekday = 'short';
+        options.hour12 = false;
+        options.timeZone = opts.timeZone;
         break;
 
       case 'long':
-        options = {
-          year: opts.withYear ? 'numeric' : undefined,
-          month: 'long',
-          day: 'numeric',
-          hour: '2-digit',
-          weekday: 'long',
-          hour12: false,
-          timeZone: opts.timeZone,
-        };
+        options.year = opts.withYear ? 'numeric' : undefined;
+        options.month = 'long';
+        options.day = 'numeric';
+        options.hour = '2-digit';
+        options.weekday = 'long';
+        options.hour12 = false;
+        options.timeZone = opts.timeZone;
         break;
     }
 
-    let formatResult = new Intl.DateTimeFormat(opts.locale, options).format(d);
-    formatResult = formatResult.replace(/[.]\s(?=.*[.])|[.]/g, (match) => {
-      switch (match) {
-        case '. ':
-          return '/';
-        case '.':
-          return '';
-        default:
-          return match;
-      }
-    });
+    const formatResult = new Intl.DateTimeFormat(opts.locale, options)
+      .format(d)
+      .replace(/[.]\s(?=.*[.])|[.]/g, (match) => {
+        switch (match) {
+          case '. ':
+            return '/';
+          case '.':
+            return '';
+          default:
+            return match;
+        }
+      });
     return format12HourInLocale(formatResult, opts.locale);
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
`formatLocalDatehourVariant1` 함수 rewriting (https://fastcampus.atlassian.net/browse/DCM-43)
- 함수 스펙
```javascript
formatLocalDatehourVariant1(new Date('2000-01-01 00:00') // => 12월 31일 금요일 자정
formatLocalDatehourVariant1(new Date('2000-01-01 12:00') // => 1월 1일 토요일 정오
formatLocalDatehourVariant1(new Date('2000-01-01 13:00') // => 1월 1일 토요일 13시
```


## 무엇을 어떻게 변경했나요?
redstone/util의 `formatLocalDatehourVariant1` 함수 스펙에 맞는 `formatInLongLocalTime` 함수 작성
(더 좋은 함수명이 있을까요? 😅)

포맷 옵션 제공시 `formatInTwoDigitLocalTime` 함수 구현때 작성했던 [`LocalDateTimeFormatOpts`](https://github.com/day1co/pebbles/blob/main/src/date-util/date-util.interface.ts#L23) 를 재활용했습니다
(redstone/util에는 없었던 년도 표기도 가능한 스펙이 추가)

사소하지만 `subtractDayIfLocaTimeIsMidnight` 함수명을 `subtractOneDayIfLocalTimeIsMidnight` 로 변경하였습니다

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
npm test

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="499" alt="Screen Shot 2022-02-13 at 5 24 06 PM" src="https://user-images.githubusercontent.com/63729090/153745095-e9714eb3-c391-4a29-a497-bcc9ea6c1d88.png">

