### PR TITLE
누락된 export 적용 & interface에 readonly 적용 & 3.0 배포

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,15 +3,17 @@ module.exports = {
     jest: true,
     node: true,
   },
-  extends: ['plugin:prettier/recommended', 'prettier', 'plugin:@typescript-eslint/recommended'],
+  extends: ['plugin:prettier/recommended', 'plugin:@typescript-eslint/recommended'],
   ignorePatterns: ['./lib'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
   plugins: ['import', '@typescript-eslint'],
+  root: true,
   rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-namespace': 'off',
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Compiled output
+# Node Modules
 node_modules/
+
+# Compiled output
 /lib/
 
 # Test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
+  coverageDirectory: '../coverage',
   preset: 'ts-jest',
+  rootDir: 'src',
   testEnvironment: 'node',
-  transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
-  },
+  transform: { '^.+\\.(ts|tsx)$': 'ts-jest' },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@day1co/pebbles",
-  "version": "1.0.7",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@day1co/pebbles",
-      "version": "1.0.7",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
@@ -6398,9 +6398,9 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+      "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
@@ -6422,9 +6422,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+      "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf ./lib ./node_modules",
+    "clean": "rimraf ./coverage ./lib ./node_modules",
     "clean:build": "rimraf ./lib",
     "lint": "eslint .",
     "prebuild": "npm-run-all clean:build lint",
     "prepublishOnly": "npm run build",
-    "test": "jest --coverage --detectOpenHandles --forceExit ./src"
+    "test": "jest --coverage --detectOpenHandles --forceExit"
   },
   "dependencies": {
     "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@day1co/pebbles",
-  "version": "1.0.7",
+  "version": "3.0.0",
   "author": "Day1Company",
   "license": "MIT",
   "main": "./lib/index.js",

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -5,7 +5,6 @@ import type {
   LocalDateTimeFormatOpts,
 } from './date-util.interface';
 import type { DateType, DatePropertyType } from './date-util.type';
-import { LoggerFactory } from '../logger';
 
 const ONE_SECOND_IN_MILLI = 1000;
 const ONE_DAY_IN_SECOND = 60 * 60 * 24;
@@ -18,8 +17,6 @@ const DEFAULT_LOCALE_TIMEZONE_FORMAT = '[Z]';
 const DATE_FORMAT = 'YYYY-MM-DD';
 const DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 const TIMESTAMP_FORMAT = 'YYYYMMDDHHmmssSSS';
-
-const logger = LoggerFactory.getLogger('pebbles:date-util');
 
 export namespace DateUtil {
   export function isValidDate(d: Date): boolean {
@@ -37,38 +34,33 @@ export namespace DateUtil {
   }
 
   export function calcDatetime(d: DateType, opts: CalcDatetimeOpts): Date {
-    try {
-      const date = parse(d);
+    const date = parse(d);
 
-      if (opts.year) {
-        date.setFullYear(date.getFullYear() + opts.year);
-      }
-
-      if (opts.month) {
-        date.setMonth(date.getMonth() + opts.month);
-      }
-
-      if (opts.date) {
-        date.setDate(date.getDate() + opts.date);
-      }
-
-      if (opts.hour) {
-        date.setHours(date.getHours() + opts.hour);
-      }
-
-      if (opts.minute) {
-        date.setMinutes(date.getMinutes() + opts.minute);
-      }
-
-      if (opts.second) {
-        date.setSeconds(date.getSeconds() + opts.second);
-      }
-
-      return date;
-    } catch (err) {
-      logger.error('calcDatetime error: %s, %s, %o', err, d, opts);
-      throw err;
+    if (opts.year) {
+      date.setFullYear(date.getFullYear() + opts.year);
     }
+
+    if (opts.month) {
+      date.setMonth(date.getMonth() + opts.month);
+    }
+
+    if (opts.date) {
+      date.setDate(date.getDate() + opts.date);
+    }
+
+    if (opts.hour) {
+      date.setHours(date.getHours() + opts.hour);
+    }
+
+    if (opts.minute) {
+      date.setMinutes(date.getMinutes() + opts.minute);
+    }
+
+    if (opts.second) {
+      date.setSeconds(date.getSeconds() + opts.second);
+    }
+
+    return date;
   }
 
   export function beginOfMonth(date: DateType = new Date()): Date {

--- a/src/date-util/index.ts
+++ b/src/date-util/index.ts
@@ -1,3 +1,8 @@
 export { DateUtil } from './date-util';
 export type { DateType } from './date-util.type';
-export type { CalcDatetimeOpts } from './date-util.interface';
+export type {
+  CalcDatetimeOpts,
+  DateFormatOpts,
+  ISODateFormatOpts,
+  LocalDateTimeFormatOpts,
+} from './date-util.interface';

--- a/src/exception/client-exception/bad-request-exception.ts
+++ b/src/exception/client-exception/bad-request-exception.ts
@@ -1,0 +1,8 @@
+import { ClientException } from './client-exception';
+import { HttpState } from '../../http-client';
+
+export class BadRequestException extends ClientException {
+  constructor(message = 'BAD_REQUEST', cause?: Error) {
+    super(HttpState.BAD_REQUEST, message, cause);
+  }
+}

--- a/src/exception/client-exception/changed-credential-exception.ts
+++ b/src/exception/client-exception/changed-credential-exception.ts
@@ -1,0 +1,8 @@
+import { ClientException } from './client-exception';
+import { HttpState } from '../../http-client';
+
+export class ChangedCredentialException extends ClientException {
+  constructor(message = 'CREDENTIAL_CHANGED', cause?: Error) {
+    super(HttpState.UNAUTHORIZED, message, cause);
+  }
+}

--- a/src/exception/client-exception/client-exception.ts
+++ b/src/exception/client-exception/client-exception.ts
@@ -1,0 +1,8 @@
+import { CustomException } from '../custom-exception';
+import { HttpState } from '../../http-client';
+
+export class ClientException extends CustomException {
+  constructor(code = HttpState.BAD_REQUEST, message = 'CLIENT_ERROR', cause?: Error) {
+    super(code, message, cause);
+  }
+}

--- a/src/exception/client-exception/forbidden-exception.ts
+++ b/src/exception/client-exception/forbidden-exception.ts
@@ -1,0 +1,8 @@
+import { ClientException } from './client-exception';
+import { HttpState } from '../../http-client';
+
+export class ForbiddenException extends ClientException {
+  constructor(message = 'FORBIDDEN', cause?: Error) {
+    super(HttpState.FORBIDDEN, message, cause);
+  }
+}

--- a/src/exception/client-exception/index.ts
+++ b/src/exception/client-exception/index.ts
@@ -1,0 +1,6 @@
+export { BadRequestException } from './bad-request-exception';
+export { ChangedCredentialException } from './changed-credential-exception';
+export { ClientException } from './client-exception';
+export { ForbiddenException } from './forbidden-exception';
+export { NotFoundException } from './not-found-exception';
+export { UnauthorizedException } from './unauthorized-exception';

--- a/src/exception/client-exception/not-found-exception.ts
+++ b/src/exception/client-exception/not-found-exception.ts
@@ -1,0 +1,8 @@
+import { ClientException } from './client-exception';
+import { HttpState } from '../../http-client';
+
+export class NotFoundException extends ClientException {
+  constructor(message = 'NOT_FOUND', cause?: Error) {
+    super(HttpState.NOT_FOUND, message, cause);
+  }
+}

--- a/src/exception/client-exception/unauthorized-exception.ts
+++ b/src/exception/client-exception/unauthorized-exception.ts
@@ -1,0 +1,8 @@
+import { ClientException } from './client-exception';
+import { HttpState } from '../../http-client';
+
+export class UnauthorizedException extends ClientException {
+  constructor(message = 'UNAUTHORIZED', cause?: Error) {
+    super(HttpState.UNAUTHORIZED, message, cause);
+  }
+}

--- a/src/exception/custom-exception.ts
+++ b/src/exception/custom-exception.ts
@@ -1,0 +1,14 @@
+import { HttpState } from '../http-client';
+
+export class CustomException extends Error {
+  readonly code: HttpState;
+  readonly cause: Error | undefined;
+
+  constructor(code = HttpState.CUSTOM_UNKNOWN_ERROR, message = 'UNKNOWN_ERROR', cause?: Error) {
+    super();
+
+    this.code = code;
+    this.message = message;
+    this.cause = cause;
+  }
+}

--- a/src/exception/exception.spec.ts
+++ b/src/exception/exception.spec.ts
@@ -1,0 +1,226 @@
+import {
+  BadRequestException,
+  ChangedCredentialException,
+  ClientException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from './client-exception';
+import { CustomException } from './custom-exception';
+import { DataException, InternalServerException, ServerException } from './server-exception';
+
+const error = new Error();
+
+describe('error', () => {
+  describe('CustomException', () => {
+    test('should have default property', () => {
+      const e = new CustomException();
+      expect(e).toBeInstanceOf(CustomException);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.code).toBe(520);
+      expect(e.message).toBe('UNKNOWN_ERROR');
+      expect(e.cause).toBeUndefined();
+    });
+    test('should have specified property', () => {
+      const e = new CustomException(123, 'hello', error);
+      expect(e).toBeInstanceOf(CustomException);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.code).toBe(123);
+      expect(e.message).toBe('hello');
+      expect(e.cause).toBe(error);
+    });
+  });
+  describe('ClientException', () => {
+    test('should have default property', () => {
+      const e = new ClientException();
+      expect(e).toBeInstanceOf(ClientException);
+      expect(e).toBeInstanceOf(CustomException);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.code).toBe(400);
+      expect(e.message).toBe('CLIENT_ERROR');
+      expect(e.cause).toBeUndefined();
+    });
+    test('should have specified property', () => {
+      const e = new ClientException(123, 'hello', error);
+      expect(e).toBeInstanceOf(ClientException);
+      expect(e).toBeInstanceOf(CustomException);
+      expect(e).toBeInstanceOf(Error);
+      expect(e.code).toBe(123);
+      expect(e.message).toBe('hello');
+      expect(e.cause).toBe(error);
+    });
+  });
+  describe('BadRequestException', () => {
+    // test('should have default property', () => {
+    const e = new BadRequestException();
+    expect(e).toBeInstanceOf(BadRequestException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(400);
+    expect(e.message).toBe('BAD_REQUEST');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new BadRequestException('hello', error);
+    expect(e).toBeInstanceOf(BadRequestException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(400);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('NotFoundException', () => {
+  test('should have default property', () => {
+    const e = new NotFoundException();
+    expect(e).toBeInstanceOf(NotFoundException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(404);
+    expect(e.message).toBe('NOT_FOUND');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new NotFoundException('hello', error);
+    expect(e).toBeInstanceOf(NotFoundException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(404);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('UnauthorizedException', () => {
+  test('should have default property', () => {
+    const e = new UnauthorizedException();
+    expect(e).toBeInstanceOf(UnauthorizedException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(401);
+    expect(e.message).toBe('UNAUTHORIZED');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new UnauthorizedException('hello', error);
+    expect(e).toBeInstanceOf(UnauthorizedException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(401);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('CredentialChangedException', () => {
+  test('should have default property', () => {
+    const e = new ChangedCredentialException();
+    expect(e).toBeInstanceOf(ChangedCredentialException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(401);
+    expect(e.message).toBe('CREDENTIAL_CHANGED');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new ChangedCredentialException('hello', error);
+    expect(e).toBeInstanceOf(ChangedCredentialException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(401);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('ForbiddenException', () => {
+  test('should have default property', () => {
+    const e = new ForbiddenException();
+    expect(e).toBeInstanceOf(ForbiddenException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(403);
+    expect(e.message).toBe('FORBIDDEN');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new ForbiddenException('hello', error);
+    expect(e).toBeInstanceOf(ForbiddenException);
+    expect(e).toBeInstanceOf(ClientException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(403);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('ServerException', () => {
+  test('should have default property', () => {
+    const e = new ServerException();
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(500);
+    expect(e.message).toBe('INTERNAL_SERVER_ERROR');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new ServerException(123, 'hello', error);
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(123);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('InternalServerException', () => {
+  test('should have default property', () => {
+    const e = new InternalServerException();
+    expect(e).toBeInstanceOf(InternalServerException);
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(500);
+    expect(e.message).toBe('INTERNAL_SERVER_ERROR');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new InternalServerException('hello', error);
+    expect(e).toBeInstanceOf(InternalServerException);
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(500);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});
+describe('DataException', () => {
+  test('should have default property', () => {
+    const e = new DataException();
+    expect(e).toBeInstanceOf(DataException);
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(500);
+    expect(e.message).toBe('DATA_ERROR');
+    expect(e.cause).toBeUndefined();
+  });
+  test('should have specified property', () => {
+    const e = new DataException('hello', error);
+    expect(e).toBeInstanceOf(DataException);
+    expect(e).toBeInstanceOf(ServerException);
+    expect(e).toBeInstanceOf(CustomException);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe(500);
+    expect(e.message).toBe('hello');
+    expect(e.cause).toBe(error);
+  });
+});

--- a/src/exception/index.ts
+++ b/src/exception/index.ts
@@ -1,0 +1,10 @@
+export {
+  BadRequestException,
+  ChangedCredentialException,
+  ClientException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from './client-exception';
+export { CustomException } from './custom-exception';
+export { DataException, InternalServerException, ServerException } from './server-exception';

--- a/src/exception/server-exception/data-exception.ts
+++ b/src/exception/server-exception/data-exception.ts
@@ -1,0 +1,8 @@
+import { ServerException } from './server-exception';
+import { HttpState } from '../../http-client';
+
+export class DataException extends ServerException {
+  constructor(message = 'DATA_ERROR', cause?: Error) {
+    super(HttpState.INTERNAL_SERVER_ERROR, message, cause);
+  }
+}

--- a/src/exception/server-exception/index.ts
+++ b/src/exception/server-exception/index.ts
@@ -1,0 +1,3 @@
+export { DataException } from './data-exception';
+export { InternalServerException } from './internal-server-exception';
+export { ServerException } from './server-exception';

--- a/src/exception/server-exception/internal-server-exception.ts
+++ b/src/exception/server-exception/internal-server-exception.ts
@@ -1,0 +1,8 @@
+import { ServerException } from './server-exception';
+import { HttpState } from '../../http-client';
+
+export class InternalServerException extends ServerException {
+  constructor(message = 'INTERNAL_SERVER_ERROR', cause?: Error) {
+    super(HttpState.INTERNAL_SERVER_ERROR, message, cause);
+  }
+}

--- a/src/exception/server-exception/server-exception.ts
+++ b/src/exception/server-exception/server-exception.ts
@@ -1,0 +1,8 @@
+import { CustomException } from '../custom-exception';
+import { HttpState } from '../../http-client';
+
+export class ServerException extends CustomException {
+  constructor(code = HttpState.INTERNAL_SERVER_ERROR, message = 'INTERNAL_SERVER_ERROR', cause?: Error) {
+    super(code, message, cause);
+  }
+}

--- a/src/http-client/http-client.interface.ts
+++ b/src/http-client/http-client.interface.ts
@@ -21,10 +21,10 @@ export interface HttpReqConfig {
 }
 
 export interface HttpRes<Type> {
-  data: Type;
-  status: number;
-  statusText: string;
-  headers: unknown;
-  config: HttpReqConfig;
-  request?: unknown;
+  readonly data: Type;
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: unknown;
+  readonly config: HttpReqConfig;
+  readonly request?: unknown;
 }

--- a/src/http-client/http-client.spec.ts
+++ b/src/http-client/http-client.spec.ts
@@ -1,41 +1,9 @@
-import { constants } from 'http2';
 import { HttpClient } from './http-client';
-import { HttpState } from './http-state.enum';
 
 describe('HttpClient', () => {
   test('Base URL get/set', () => {
     const httpClient = new HttpClient();
     httpClient.baseUrl = 'baseUrl';
     expect(httpClient.baseUrl === 'baseUrl').toBe(true);
-  });
-});
-
-describe('HttpState', () => {
-  test('http state code number', () => {
-    const OK: HttpState = HttpState.OK;
-    const CREATED: HttpState = HttpState.CREATED;
-    const ACCEPTED: HttpState = HttpState.ACCEPTED;
-    const NO_CONTENT: HttpState = HttpState.NO_CONTENT;
-    const BAD_REQUEST: HttpState = HttpState.BAD_REQUEST;
-    const UNAUTHORIZED: HttpState = HttpState.UNAUTHORIZED;
-    const FORBIDDEN: HttpState = HttpState.FORBIDDEN;
-    const NOT_FOUND: HttpState = HttpState.NOT_FOUND;
-    const TEAPOT: HttpState = HttpState.TEAPOT;
-    const INTERNAL_SERVER_ERROR: HttpState = HttpState.INTERNAL_SERVER_ERROR;
-    const SERVICE_UNAVAILABLE: HttpState = HttpState.SERVICE_UNAVAILABLE;
-    const CUSTOM_UNKNOWN_ERROR: HttpState = HttpState.CUSTOM_UNKNOWN_ERROR;
-
-    expect(OK).toEqual(constants.HTTP_STATUS_OK);
-    expect(CREATED).toEqual(constants.HTTP_STATUS_CREATED);
-    expect(ACCEPTED).toEqual(constants.HTTP_STATUS_ACCEPTED);
-    expect(NO_CONTENT).toEqual(constants.HTTP_STATUS_NO_CONTENT);
-    expect(BAD_REQUEST).toEqual(constants.HTTP_STATUS_BAD_REQUEST);
-    expect(UNAUTHORIZED).toEqual(constants.HTTP_STATUS_UNAUTHORIZED);
-    expect(FORBIDDEN).toEqual(constants.HTTP_STATUS_FORBIDDEN);
-    expect(NOT_FOUND).toEqual(constants.HTTP_STATUS_NOT_FOUND);
-    expect(TEAPOT).toEqual(constants.HTTP_STATUS_TEAPOT);
-    expect(INTERNAL_SERVER_ERROR).toEqual(constants.HTTP_STATUS_INTERNAL_SERVER_ERROR);
-    expect(SERVICE_UNAVAILABLE).toEqual(constants.HTTP_STATUS_SERVICE_UNAVAILABLE);
-    expect(CUSTOM_UNKNOWN_ERROR).toEqual(520);
   });
 });

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,15 +1,8 @@
 import axios from 'axios';
 import type { HttpReqConfig, HttpRes } from './http-client.interface';
-import { LoggerFactory } from '../logger';
-import type { Logger } from '../logger';
 
 export class HttpClient {
-  private readonly logger: Logger;
   private _baseUrl = '';
-
-  constructor() {
-    this.logger = LoggerFactory.getLogger('pebbles:http-client');
-  }
 
   get baseUrl(): string {
     return this._baseUrl;
@@ -21,25 +14,21 @@ export class HttpClient {
 
   sendGetRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`getRequest to %s with config: %o`, fullUrl, config);
     return axios.get<Type, HttpRes<Type>>(fullUrl, config);
   }
 
   sendPostRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`postRequest to %s with data: %o, config: %o`, fullUrl, data, config);
     return axios.post<Type, HttpRes<Type>>(fullUrl, data, config);
   }
 
   sendPutRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`putRequest to %s with data: %o, config: %o`, fullUrl, data, config);
     return axios.put<Type, HttpRes<Type>>(fullUrl, data, config);
   }
 
   sendDeleteRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
     const fullUrl = this.getFullUrl(url);
-    this.logger.debug(`deleteRequest to %s with config: %o`, fullUrl, config);
     return axios.delete<Type, HttpRes<Type>>(fullUrl, config);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,18 @@ export type {
   ISODateFormatOpts,
   LocalDateTimeFormatOpts,
 } from './date-util';
+export {
+  BadRequestException,
+  ChangedCredentialException,
+  ClientException,
+  CustomException,
+  DataException,
+  ForbiddenException,
+  InternalServerException,
+  NotFoundException,
+  ServerException,
+  UnauthorizedException,
+} from './exception';
 export { HttpClient, HttpState } from './http-client';
 export type { HttpReqConfig, HttpRes } from './http-client';
 export { LoggerFactory } from './logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,20 @@
 export { BooleanUtil } from './boolean-util';
 export { DateUtil } from './date-util';
-export type { DateType, CalcDatetimeOpts } from './date-util';
+export type {
+  CalcDatetimeOpts,
+  DateType,
+  DateFormatOpts,
+  ISODateFormatOpts,
+  LocalDateTimeFormatOpts,
+} from './date-util';
 export { HttpClient, HttpState } from './http-client';
 export type { HttpReqConfig, HttpRes } from './http-client';
 export { LoggerFactory } from './logger';
 export type { Logger, LogLevel } from './logger';
 export { MiscUtil } from './misc-util';
-export type { PageInfo, Pagination, PageDetail } from './misc-util';
+export type { PageDetail, PageInfo, Pagination } from './misc-util';
 export { NumberUtil } from './number-util';
 export { ObjectUtil } from './object-util';
 export type { ObjectType, ObjectKeyType } from './object-util';
 export { StringUtil } from './string-util';
-export type { Tag } from './string-util';
+export type { Tag, TemplateOpts } from './string-util';

--- a/src/logger/logger-factory.ts
+++ b/src/logger/logger-factory.ts
@@ -1,5 +1,5 @@
 import type { Logger } from './logger.interface';
-import { PinoLogger } from './pino-logger';
+import { PinoLogger } from './logger-impl/pino-logger';
 
 export class LoggerFactory {
   private readonly loggerMap: Map<string, Logger>;

--- a/src/logger/logger-impl/pino-logger.ts
+++ b/src/logger/logger-impl/pino-logger.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
-import type { Logger } from './logger.interface';
-import { LogLevel } from './logger.type';
+import type { Logger } from '../logger.interface';
+import { LogLevel } from '../logger.type';
 
 export class PinoLogger implements Logger {
   private readonly logger: pino.Logger;

--- a/src/misc-util/index.ts
+++ b/src/misc-util/index.ts
@@ -1,2 +1,2 @@
 export { MiscUtil } from './misc-util';
-export type { PageInfo, Pagination, PageDetail } from './misc-util.interface';
+export type { PageDetail, PageInfo, Pagination } from './misc-util.interface';

--- a/src/misc-util/misc-util.interface.ts
+++ b/src/misc-util/misc-util.interface.ts
@@ -1,3 +1,9 @@
+export interface PageDetail {
+  readonly page: number;
+  readonly offset: number;
+  readonly active: boolean;
+}
+
 export interface PageInfo {
   readonly count: number;
   readonly limit: number;
@@ -7,14 +13,8 @@ export interface PageInfo {
 }
 
 export interface Pagination {
-  currentPage: number;
-  firstPage: number;
-  lastPage: number;
-  pages: PageDetail[];
-}
-
-export interface PageDetail {
-  page: number;
-  offset: number;
-  active: boolean;
+  readonly currentPage: number;
+  readonly firstPage: number;
+  readonly lastPage: number;
+  readonly pages: PageDetail[];
 }

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -1,14 +1,10 @@
-import { LoggerFactory } from '../logger';
 import { ObjectKeyType, ObjectType } from './object-util.type';
-
-const logger = LoggerFactory.getLogger('pebbles:object-util');
 
 export namespace ObjectUtil {
   export function serialize(obj: ObjectType): string | null {
     try {
       return JSON.stringify(obj);
     } catch (exception) {
-      logger.warn('Error occurred while serializing - %s', exception);
       return null;
     }
   }
@@ -17,7 +13,6 @@ export namespace ObjectUtil {
     try {
       return JSON.parse(str);
     } catch (exception) {
-      logger.warn('Error occurred while deserializing - %s', exception);
       return null;
     }
   }

--- a/src/string-util/index.ts
+++ b/src/string-util/index.ts
@@ -1,2 +1,2 @@
 export { StringUtil } from './string-util';
-export type { Tag } from './string-util.interface';
+export type { Tag, TemplateOpts } from './string-util.interface';

--- a/src/string-util/string-util.interface.ts
+++ b/src/string-util/string-util.interface.ts
@@ -1,7 +1,7 @@
 import { ObjectType } from '../object-util';
 
 export interface Tag {
-  text: string;
+  readonly text: string;
 }
 
 export interface TemplateOpts {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,6 @@
     "newLine": "lf",
     "outDir": "./lib",
     "sourceMap": true,
-    "allowJs": true,
-    "checkJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "target": "esnext"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "checkJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "target": "es2021"
+    "target": "esnext"
   },
   "include": ["./src"],
   "exclude": ["./lib", "./node_modules"]


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
일부 interface의 export가 누락됨
interface property에 readonly가 누락된 것들이 있음
pebbles 내무의 logger 사용 제거
tsconfig target을 esnext로 변경
버전 3.0으로 올림

## 어떻게 테스트 하셨나요?
npm run test
