### PR TITLE
TS target을 es2021로 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,9 @@
 module.exports = {
-  env: {
-    jest: true,
-    node: true,
-  },
+  env: { jest: true },
   extends: ['plugin:prettier/recommended', 'plugin:@typescript-eslint/recommended'],
-  ignorePatterns: ['./lib'],
+  ignorePatterns: ['/lib'],
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-  },
+  parserOptions: { ecmaVersion: '2021', sourceType: 'module' },
   plugins: ['import', '@typescript-eslint'],
   root: true,
   rules: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "target": "esnext"
+    "target": "es2021"
   },
   "include": ["./src"],
   "exclude": ["./lib", "./node_modules"]


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
TS 컴파일 타겟을 node 16이 지원 가능한 es2021로 변경해야한다.
