### PR TITLE
calcDatetime 코드를 더 짧고 더 효율적으로

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,7 @@ name: CI-Test
 on:
   pull_request:
     branches:
-      - main
+      - **
 
 defaults:
   run:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,7 @@ name: CI-Test
 on:
   pull_request:
     branches:
-      - **
+      - '**'
 
 defaults:
   run:

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -47,15 +47,13 @@ export namespace DateUtil {
       date.setMonth(date.getMonth() + opts.month);
     }
 
-    const result = new Date(
+    return new Date(
       date.getTime() +
         (opts.date ?? 0) * ONE_DAY_IN_MILLI +
         (opts.hour ?? 0) * ONE_HOUR_IN_MILLI +
         (opts.minute ?? 0) * ONE_MINUTE_IN_MILLI +
         (opts.second ?? 0) * ONE_SECOND_IN_MILLI
     );
-
-    return result;
   }
 
   export function beginOfMonth(date: DateType = new Date()): Date {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -7,9 +7,12 @@ import type {
 import type { DateType, DatePropertyType } from './date-util.type';
 
 const ONE_SECOND_IN_MILLI = 1000;
-const ONE_DAY_IN_SECOND = 60 * 60 * 24;
-const ONE_HOUR_IN_SECOND = 60 * 60;
 const ONE_MINUTE_IN_SECOND = 60;
+const ONE_HOUR_IN_SECOND = 60 * ONE_MINUTE_IN_SECOND;
+const ONE_DAY_IN_SECOND = 24 * ONE_HOUR_IN_SECOND;
+const ONE_MINUTE_IN_MILLI = ONE_MINUTE_IN_SECOND * ONE_SECOND_IN_MILLI;
+const ONE_HOUR_IN_MILLI = ONE_HOUR_IN_SECOND * ONE_MINUTE_IN_MILLI;
+const ONE_DAY_IN_MILLI = ONE_DAY_IN_SECOND * ONE_HOUR_IN_MILLI;
 
 const DEFAULT_UTC_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 const DEFAULT_LOCALE_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss[Z]';
@@ -34,7 +37,7 @@ export namespace DateUtil {
   }
 
   export function calcDatetime(d: DateType, opts: CalcDatetimeOpts): Date {
-    const date = parse(d);
+    const date = DateUtil.parse(d);
 
     if (opts.year) {
       date.setFullYear(date.getFullYear() + opts.year);
@@ -44,23 +47,15 @@ export namespace DateUtil {
       date.setMonth(date.getMonth() + opts.month);
     }
 
-    if (opts.date) {
-      date.setDate(date.getDate() + opts.date);
-    }
+    const result = new Date(
+      date.getTime() +
+        (opts.date ?? 0) * ONE_DAY_IN_MILLI +
+        (opts.hour ?? 0) * ONE_HOUR_IN_MILLI +
+        (opts.minute ?? 0) * ONE_MINUTE_IN_MILLI +
+        (opts.second ?? 0) * ONE_SECOND_IN_MILLI
+    );
 
-    if (opts.hour) {
-      date.setHours(date.getHours() + opts.hour);
-    }
-
-    if (opts.minute) {
-      date.setMinutes(date.getMinutes() + opts.minute);
-    }
-
-    if (opts.second) {
-      date.setSeconds(date.getSeconds() + opts.second);
-    }
-
-    return date;
+    return result;
   }
 
   export function beginOfMonth(date: DateType = new Date()): Date {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -11,8 +11,8 @@ const ONE_MINUTE_IN_SECOND = 60;
 const ONE_HOUR_IN_SECOND = 60 * ONE_MINUTE_IN_SECOND;
 const ONE_DAY_IN_SECOND = 24 * ONE_HOUR_IN_SECOND;
 const ONE_MINUTE_IN_MILLI = ONE_MINUTE_IN_SECOND * ONE_SECOND_IN_MILLI;
-const ONE_HOUR_IN_MILLI = ONE_HOUR_IN_SECOND * ONE_MINUTE_IN_MILLI;
-const ONE_DAY_IN_MILLI = ONE_DAY_IN_SECOND * ONE_HOUR_IN_MILLI;
+const ONE_HOUR_IN_MILLI = ONE_HOUR_IN_SECOND * ONE_SECOND_IN_MILLI;
+const ONE_DAY_IN_MILLI = ONE_DAY_IN_SECOND * ONE_SECOND_IN_MILLI;
 
 const DEFAULT_UTC_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 const DEFAULT_LOCALE_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss[Z]';
@@ -37,7 +37,7 @@ export namespace DateUtil {
   }
 
   export function calcDatetime(d: DateType, opts: CalcDatetimeOpts): Date {
-    const date = DateUtil.parse(d);
+    const date = parse(d);
 
     if (opts.year) {
       date.setFullYear(date.getFullYear() + opts.year);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
calcDatetime 코드가 필요 이상으로 길다.

## 무엇을 어떻게 변경했나요?
millisecond 계산이 불가능한 연/월 계산을 제외하고 나머지는 if문 없이 millisecond 계산으로 처리한다.

## 어떻게 테스트 하셨나요?
npm run test
