### PR TITLE
불필요한 setUTCOffset 함수 제거

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -299,24 +299,6 @@ describe('DateUtil', () => {
     });
   });
 
-  describe('setUTCOffset', () => {
-    const testDate1 = '2020-01-01 01:01:01Z';
-    const testDate2 = '2020-01-01 00:00:00-09:00';
-    const testDate3 = '2020-01-01 00:00:00+09:00';
-
-    it('should set given date`s utc time by given offset', () => {
-      expect(DateUtil.setUTCOffset(new Date(testDate1), 180)).toEqual(new Date('2020-01-01 04:01:01Z'));
-      expect(DateUtil.setUTCOffset(new Date(testDate2), 180)).toEqual(new Date('2020-01-01 12:00:00Z'));
-      expect(DateUtil.setUTCOffset(new Date(testDate3), 540)).toEqual(new Date('2020-01-01 00:00:00Z'));
-    });
-
-    it('should parse string to date and set it`s utc time by given offset', () => {
-      expect(DateUtil.setUTCOffset(testDate1, 180)).toEqual(new Date('2020-01-01 04:01:01Z'));
-      expect(DateUtil.setUTCOffset(testDate2, 180)).toEqual(new Date('2020-01-01 12:00:00Z'));
-      expect(DateUtil.setUTCOffset(testDate3, 540)).toEqual(new Date('2020-01-01 00:00:00Z'));
-    });
-  });
-
   describe('format', () => {
     it('should throw with invalid format string', () => {
       expect(() => DateUtil.format(new Date(), { format: 'y년 m월 d일' })).toThrow();

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -57,18 +57,18 @@ export namespace DateUtil {
   }
 
   export function beginOfMonth(date: DateType = new Date()): Date {
-    date = parse(date);
-    return new Date(date.getFullYear(), date.getMonth(), 1);
+    const parsedDate = parse(date);
+    return new Date(parsedDate.getFullYear(), parsedDate.getMonth(), 1);
   }
 
   export function endOfMonth(date: DateType = new Date()): Date {
-    date = parse(date);
-    return new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
+    const parsedDate = parse(date);
+    return new Date(parsedDate.getFullYear(), parsedDate.getMonth() + 1, 0, 23, 59, 59, 999);
   }
 
   export function lastDayOfMonth(date: DateType = new Date()): Date {
-    date = parse(date);
-    return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+    const parsedDate = parse(date);
+    return new Date(parsedDate.getFullYear(), parsedDate.getMonth() + 1, 0);
   }
 
   export function diff(since: DateType, until: DateType, type: DatePropertyType): number {
@@ -212,10 +212,6 @@ export namespace DateUtil {
     }
     unixTime *= ONE_SECOND_IN_MILLI;
     return parse(unixTime);
-  }
-
-  export function setUTCOffset(d: DateType, offsetMinute: number): Date {
-    return new Date(parse(d).getTime() + offsetMinute * ONE_SECOND_IN_MILLI * ONE_MINUTE_IN_SECOND);
   }
 
   export function format(d: Date, opts?: DateFormatOpts): string {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
기존 fastcampus/util의 utcOffset 함수는 moment 객체의 offset을 바꾸기 위한 것.
그런데 지금 setUTCOffset 함수는 시각 자체를 바꾸고 있다.

## 무엇을 어떻게 변경했나요?
setUTCOffset 함수 삭제

## 어떻게 테스트 하셨나요?
npm run test
