### PR TITLE
HttpClient에 생성자 추가 및 HttpRes를 HttpResponse로 변경

### DIFF
--- a/src/http-client/http-client.spec.ts
+++ b/src/http-client/http-client.spec.ts
@@ -2,20 +2,21 @@ import http from 'http';
 import { HttpClient } from './http-client';
 
 describe('HttpClient', () => {
-  const httpClient = new HttpClient();
-  const testPort = 9999;
+  const TEST_SERVER = 'http://localhost:9999';
+  const TEST_PORT = 9999;
   const server = http.createServer((req, res) => {
     res.end(JSON.stringify('HttpClient test is OK'));
   });
 
   test('Base URL get/set', () => {
-    httpClient.baseUrl = 'http://localhost:9999';
-    expect(httpClient.baseUrl === 'http://localhost:9999').toBe(true);
+    const httpClient = new HttpClient();
+    httpClient.baseUrl = TEST_SERVER;
+    expect(httpClient.baseUrl === TEST_SERVER).toBe(true);
   });
 
   describe('Http communication', () => {
     beforeAll((done) => {
-      server.listen(testPort, done);
+      server.listen(TEST_PORT, done);
       server.on('clientError', (err, socket) => {
         socket.end();
       });
@@ -24,6 +25,8 @@ describe('HttpClient', () => {
     afterAll((done) => {
       server.close(done);
     });
+
+    const httpClient = new HttpClient(TEST_SERVER);
 
     it('Http GET test', async () => {
       const result = await httpClient.sendGetRequest('/');

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
-import type { HttpReqConfig, HttpRes } from './http-client.type';
+import type { HttpReqConfig, HttpResponse } from './http-client.type';
 
 export class HttpClient {
   private _baseUrl = '';
+
+  constructor(baseUrl?: string) {
+    this._baseUrl = baseUrl ?? '';
+  }
 
   get baseUrl(): string {
     return this._baseUrl;
@@ -12,24 +16,24 @@ export class HttpClient {
     this._baseUrl = baseUrl;
   }
 
-  sendGetRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
+  sendGetRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpResponse<Type>> {
     const fullUrl = this.getFullUrl(url);
-    return axios.get<Type, HttpRes<Type>>(fullUrl, config);
+    return axios.get<Type, HttpResponse<Type>>(fullUrl, config);
   }
 
-  sendPostRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
+  sendPostRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpResponse<Type>> {
     const fullUrl = this.getFullUrl(url);
-    return axios.post<Type, HttpRes<Type>>(fullUrl, data, config);
+    return axios.post<Type, HttpResponse<Type>>(fullUrl, data, config);
   }
 
-  sendPutRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpRes<Type>> {
+  sendPutRequest<Type>(url: string, data: unknown, config?: HttpReqConfig): Promise<HttpResponse<Type>> {
     const fullUrl = this.getFullUrl(url);
-    return axios.put<Type, HttpRes<Type>>(fullUrl, data, config);
+    return axios.put<Type, HttpResponse<Type>>(fullUrl, data, config);
   }
 
-  sendDeleteRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpRes<Type>> {
+  sendDeleteRequest<Type>(url: string, config?: HttpReqConfig): Promise<HttpResponse<Type>> {
     const fullUrl = this.getFullUrl(url);
-    return axios.delete<Type, HttpRes<Type>>(fullUrl, config);
+    return axios.delete<Type, HttpResponse<Type>>(fullUrl, config);
   }
 
   private getFullUrl(url: string): string {

--- a/src/http-client/http-client.type.ts
+++ b/src/http-client/http-client.type.ts
@@ -1,4 +1,7 @@
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export type HttpReqConfig = AxiosRequestConfig;
-export type HttpRes<T> = AxiosResponse<T>;
+export type HttpResponse<T> = AxiosResponse<T>;
+
+/** @deprecated */
+export type HttpRes<T> = HttpResponse<T>;

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,3 +1,3 @@
 export { HttpClient } from './http-client';
 export { HttpState } from './http-state.enum';
-export type { HttpReqConfig, HttpRes } from './http-client.type';
+export type { HttpReqConfig, HttpRes, HttpResponse } from './http-client.type';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
   UnauthorizedException,
 } from './exception';
 export { HttpClient, HttpState } from './http-client';
-export type { HttpReqConfig, HttpRes } from './http-client';
+export type { HttpReqConfig, HttpRes, HttpResponse } from './http-client';
 export { LoggerFactory } from './logger';
 export type { Logger, LogLevel } from './logger';
 export { MiscUtil } from './misc-util';


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 무엇을 어떻게 변경했나요?
HttpClient 생성시 baseUrl을 입력 인자로 받을 수 있게 함
HttpRes를 deprecated 처리하고 HttpResponse로 대체

## 어떻게 테스트 하셨나요?
npm run test
