### PR TITLE
DateUtil - beginOfDay, endOfDay 추가

### DIFF
--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -68,6 +68,48 @@ describe('DateUtil', () => {
     });
   });
 
+  describe('beginOfDay', () => {
+    it('should throw error when invalid Date given', () => {
+      const described_function = DateUtil.beginOfDay;
+      expect(() => described_function('zzzzz')).toThrow();
+      expect(() => described_function('2021-13-01 00:00:00')).toThrow();
+      expect(() => described_function(new Date('zzzzz'))).toThrow();
+    });
+
+    it('should accept Date object and return 00:00:00 of the day', () => {
+      expect(DateUtil.beginOfDay(new Date('2021-06-03 00:00:00'))).toEqual(new Date('2021-06-03 00:00:00'));
+      expect(DateUtil.beginOfDay(new Date('2021-07-23 12:00:00'))).toEqual(new Date('2021-07-23 00:00:00'));
+      expect(DateUtil.beginOfDay(new Date('2021-08-31 23:59:59'))).toEqual(new Date('2021-08-31 00:00:00'));
+    });
+
+    it('should accept string date and return 00:00:00 of the day', () => {
+      expect(DateUtil.beginOfDay('2021-06-03 00:00:00')).toEqual(new Date('2021-06-03 00:00:00'));
+      expect(DateUtil.beginOfDay('2021-07-23 12:00:00')).toEqual(new Date('2021-07-23 00:00:00'));
+      expect(DateUtil.beginOfDay('2021-08-31 23:59:59')).toEqual(new Date('2021-08-31 00:00:00'));
+    });
+  });
+
+  describe('endOfDay', () => {
+    it('should throw error when invalid Date given', () => {
+      const described_function = DateUtil.endOfDay;
+      expect(() => described_function('zzzzz')).toThrow();
+      expect(() => described_function('2021-13-01 00:00:00')).toThrow();
+      expect(() => described_function(new Date('zzzzz'))).toThrow();
+    });
+
+    it('should accept Date object and return 23:59:59 of the day', () => {
+      expect(DateUtil.endOfDay(new Date('2021-06-03 00:00:00'))).toEqual(new Date('2021-06-03 23:59:59.999'));
+      expect(DateUtil.endOfDay(new Date('2021-07-23 12:00:00'))).toEqual(new Date('2021-07-23 23:59:59.999'));
+      expect(DateUtil.endOfDay(new Date('2021-08-31 23:59:59'))).toEqual(new Date('2021-08-31 23:59:59.999'));
+    });
+
+    it('should accept string date and return 23:59:59 of the day', () => {
+      expect(DateUtil.endOfDay('2021-06-03 00:00:00')).toEqual(new Date('2021-06-03 23:59:59.999'));
+      expect(DateUtil.endOfDay('2021-07-23 12:00:00')).toEqual(new Date('2021-07-23 23:59:59.999'));
+      expect(DateUtil.endOfDay('2021-08-31 23:59:59')).toEqual(new Date('2021-08-31 23:59:59.999'));
+    });
+  });
+
   describe('beginOfMonth', () => {
     const beginOfMonth = DateUtil.beginOfMonth;
     it('should throw error when invalid Date given', () => {

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -63,6 +63,16 @@ export namespace DateUtil {
     return date;
   }
 
+  export function beginOfDay(date: DateType = new Date()): Date {
+    date = parse(date);
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  export function endOfDay(date: DateType = new Date()): Date {
+    date = parse(date);
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
+  }
+
   export function beginOfMonth(date: DateType = new Date()): Date {
     date = parse(date);
     return new Date(date.getFullYear(), date.getMonth(), 1);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
redstone-database-schema 에서 moment() 의존성을 pebbles로 대체하기 위해 관련 메서드 추가

## 무엇을 어떻게 변경했나요?
`beginOfDay` , `endOfDay` 메서드 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

https://github.com/day1co/redstone-database-schema/pull/21

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
스펙추가 

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
