### PR TITLE
fix: pino loggger, bind this its instance

### DIFF
--- a/src/logger/pino-logger.spec.ts
+++ b/src/logger/pino-logger.spec.ts
@@ -1,0 +1,17 @@
+import { PinoLogger } from './pino-logger';
+
+describe('PinoLogger', () => {
+  describe('debug', () => {
+    it('should pass when called as instance method', () => {
+      const name = 'test';
+      const pinoLogger = new PinoLogger(name);
+      pinoLogger.debug('logging');
+    });
+
+    it('should pass when called as global context', () => {
+      const name = 'test';
+      const { debug } = new PinoLogger(name);
+      debug('logging');
+    });
+  });
+});

--- a/src/logger/pino-logger.ts
+++ b/src/logger/pino-logger.ts
@@ -13,19 +13,19 @@ export class PinoLogger implements Logger {
     this.logger.level = level;
   }
 
-  debug(msgTemplate: string, ...args: unknown[]): void {
+  debug = (msgTemplate: string, ...args: unknown[]): void => {
     this.logger.debug(msgTemplate, ...args);
-  }
+  };
 
-  info(msgTemplate: string, ...args: unknown[]): void {
+  info = (msgTemplate: string, ...args: unknown[]): void => {
     this.logger.info(msgTemplate, ...args);
-  }
+  };
 
-  warn(msgTemplate: string, ...args: unknown[]): void {
+  warn = (msgTemplate: string, ...args: unknown[]): void => {
     this.logger.warn(msgTemplate, ...args);
-  }
+  };
 
-  error(msgTemplate: string, ...args: unknown[]): void {
+  error = (msgTemplate: string, ...args: unknown[]): void => {
     this.logger.error(msgTemplate, ...args);
-  }
+  };
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

로그 메서드를 글로벌 컨텍스트에서 사용하고 싶다.

```
const { debug } = LoggerFactory.getLogger('pebbles:http-client');
```

## 무엇을 어떻게 변경했나요?

pinoLogger 의 `debug`, `info`, `warn`, `error` 의 context 를 arrow function 을 사용해 고정했다. 

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
