### PR TITLE
isValidKoreaPhoneNumber, normalizeKoreaPhoneNumber 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,12 +32,13 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -609,9 +610,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1014,10 +1015,33 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.0.tgz",
+      "integrity": "sha512-YH+BnkvuCiPR+MUOY6JIArdTIGrRtsxnLaIxPRy4CpGJ/V6OO6Gq/1J+FJEc4j5e5h6Bcy3/K7prlMrm93BJoA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.0.0.tgz",
+      "integrity": "sha512-LcqVnHCjOAj8BTCtjpwYZCMTn4yArusbdObCVRUYvBHhrR5fVLVyENG+UVWM4T4H/ufv7NiBLdprllxWs/5PaQ==",
+      "deprecated": "incorrect UMD name",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -1030,9 +1054,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.5.tgz",
-      "integrity": "sha512-JVOWdxPmgNsrNKVyhFNB08go/kCnXUT5m3Ds11F3lh3oKzCHTzs3IHRC9VI0t8mNyL4TfypxTiwQPU+77Sfm6g==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -1134,9 +1158,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.0.tgz",
-      "integrity": "sha512-r8aveDbd+rzGP+ykSdF3oPuTVRWRfbBiHl0rVDM2yNEmSMXfkObQLV46b4RnCv3Lra51OlfnZhkkFaDl2MIRaA==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -1204,9 +1228,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
       "dev": true
     },
     "node_modules/@types/pino": {
@@ -1268,14 +1292,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
-      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/type-utils": "5.20.0",
-        "@typescript-eslint/utils": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/type-utils": "5.21.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1301,14 +1325,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
-      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/typescript-estree": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1328,13 +1352,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
-      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/visitor-keys": "5.20.0"
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1345,12 +1369,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
-      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.20.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1371,9 +1395,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
-      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1384,13 +1408,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
-      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/visitor-keys": "5.20.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1411,15 +1435,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
-      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/typescript-estree": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1435,12 +1459,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
-      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/types": "5.21.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -1458,9 +1482,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1802,9 +1826,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
       "dev": true,
       "funding": [
         {
@@ -1817,10 +1841,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
+        "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -2198,9 +2222,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.114",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.114.tgz",
-      "integrity": "sha512-gRwLpVYWHGbERPU6o8pKfR168V6enWEXzZc6zQNNXbgJ7UJna+9qzAIHY94+9KOv71D/CH+QebLA9pChD2q8zA==",
+      "version": "1.4.123",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+      "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2394,12 +2418,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3610,9 +3634,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-      "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -6124,14 +6148,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -6416,12 +6440,13 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
@@ -6855,9 +6880,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -7174,10 +7199,26 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.0.tgz",
+      "integrity": "sha512-YH+BnkvuCiPR+MUOY6JIArdTIGrRtsxnLaIxPRy4CpGJ/V6OO6Gq/1J+FJEc4j5e5h6Bcy3/K7prlMrm93BJoA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+      "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.0.0.tgz",
+      "integrity": "sha512-LcqVnHCjOAj8BTCtjpwYZCMTn4yArusbdObCVRUYvBHhrR5fVLVyENG+UVWM4T4H/ufv7NiBLdprllxWs/5PaQ==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -7187,9 +7228,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.5.tgz",
-      "integrity": "sha512-JVOWdxPmgNsrNKVyhFNB08go/kCnXUT5m3Ds11F3lh3oKzCHTzs3IHRC9VI0t8mNyL4TfypxTiwQPU+77Sfm6g==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -7279,9 +7320,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.0.tgz",
-      "integrity": "sha512-r8aveDbd+rzGP+ykSdF3oPuTVRWRfbBiHl0rVDM2yNEmSMXfkObQLV46b4RnCv3Lra51OlfnZhkkFaDl2MIRaA==",
+      "version": "7.17.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -7349,9 +7390,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-      "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+      "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
       "dev": true
     },
     "@types/pino": {
@@ -7413,14 +7454,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
-      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
+      "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/type-utils": "5.20.0",
-        "@typescript-eslint/utils": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/type-utils": "5.21.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -7430,52 +7471,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
-      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
+      "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/typescript-estree": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
-      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.21.0.tgz",
+      "integrity": "sha512-XTX0g0IhvzcH/e3393SvjRCfYQxgxtYzL3UREteUneo72EFlt7UNoiYnikUtmGVobTbhUDByhJ4xRBNe+34kOQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/visitor-keys": "5.20.0"
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
-      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.21.0.tgz",
+      "integrity": "sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.20.0",
+        "@typescript-eslint/utils": "5.21.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
-      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.21.0.tgz",
+      "integrity": "sha512-XnOOo5Wc2cBlq8Lh5WNvAgHzpjnEzxn4CJBwGkcau7b/tZ556qrWXQz4DJyChYg8JZAD06kczrdgFPpEQZfDsA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
-      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.21.0.tgz",
+      "integrity": "sha512-Y8Y2T2FNvm08qlcoSMoNchh9y2Uj3QmjtwNMdRQkcFG7Muz//wfJBGBxh8R7HAGQFpgYpdHqUpEoPQk+q9Kjfg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/visitor-keys": "5.20.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/visitor-keys": "5.21.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -7484,26 +7525,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
-      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.21.0.tgz",
+      "integrity": "sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.20.0",
-        "@typescript-eslint/types": "5.20.0",
-        "@typescript-eslint/typescript-estree": "5.20.0",
+        "@typescript-eslint/scope-manager": "5.21.0",
+        "@typescript-eslint/types": "5.21.0",
+        "@typescript-eslint/typescript-estree": "5.21.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
-      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.21.0.tgz",
+      "integrity": "sha512-SX8jNN+iHqAF0riZQMkm7e8+POXa/fXw5cxL+gjpyP+FI+JVNhii53EmQgDAfDcBpFekYSlO0fGytMQwRiMQCA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/types": "5.21.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -7514,9 +7555,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-globals": {
@@ -7772,15 +7813,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
+        "caniuse-lite": "^1.0.30001332",
+        "electron-to-chromium": "^1.4.118",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
+        "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
       }
     },
@@ -8068,9 +8109,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.114",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.114.tgz",
-      "integrity": "sha512-gRwLpVYWHGbERPU6o8pKfR168V6enWEXzZc6zQNNXbgJ7UJna+9qzAIHY94+9KOv71D/CH+QebLA9pChD2q8zA==",
+      "version": "1.4.123",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.123.tgz",
+      "integrity": "sha512-0pHGE53WkYoFbsgwYcVKEpWa6jbzlvkohIEA2CUoZ9b5KC+w/zlMiQHvW/4IBcOh7YoEFqRNavgTk02TBoUTUw==",
       "dev": true
     },
     "emittery": {
@@ -8215,12 +8256,12 @@
       }
     },
     "eslint": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
-      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.1",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -9108,9 +9149,9 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-      "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",
@@ -11007,14 +11048,14 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -116,88 +116,120 @@ describe('StringUtil', () => {
 
   describe('normalizePhoneNumber', () => {
     it('should normalize phone number starting with 010 or 070', () => {
-      expect(StringUtil.normalizePhoneNumber('01012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('010-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('010 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('07012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('070-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('070.1234.5678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('01012345678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('010-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('010 1234 5678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('07012345678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('070-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('070.1234.5678')).toBe('07012345678');
     });
 
     it('should normalize phone number starting with +82 or +082', () => {
       // 010
-      expect(StringUtil.normalizePhoneNumber('+0821012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+08201012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+082-10-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+082-010-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+082--10 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+082 010 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+8201012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+821012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+82-010-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+82-10-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('+82 10 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+0821012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+08201012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082-10-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082-010-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082--10 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082 010 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+8201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('+821012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+82-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('+82-10-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+82 10 1234 5678')).toBe('01012345678');
 
       // 070
-      expect(StringUtil.normalizePhoneNumber('+0827012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+08207012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+082 070 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+082-070-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+082 70 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+082-70-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+82 070 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+82-070-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+827012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+8207012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+82 70 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('+82-70-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+0827012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+08207012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082 070 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082-070-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082 70 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+082-70-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+82 070 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+82-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('+827012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+8207012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('+82 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('+82-70-1234-5678')).toBe('07012345678');
     });
 
     it('should normalize phone number starting with 82 or 082', () => {
       // 010
-      expect(StringUtil.normalizePhoneNumber('08201012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('0821012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('082 10 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('082 010 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('082-10-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('082-010-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('821012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('8201012345678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('82-10-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('82-010-1234-5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('82 10 1234 5678')).toBe('01012345678');
-      expect(StringUtil.normalizePhoneNumber('82 010 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('08201012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('0821012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082 10 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082 010 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082-10-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082-010-1234-5678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('821012345678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('8201012345678')).toBe('01012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('82-10-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82-010-1234-5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82 10 1234 5678')).toBe('01012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82 010 1234 5678')).toBe('01012345678');
 
       // 070
-      expect(StringUtil.normalizePhoneNumber('082 70 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('082-70-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('082 070 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('082-070-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('082 70 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('082-70-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('82 070 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('82-070-1234-5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('827012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('8207012345678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('82 70 1234 5678')).toBe('07012345678');
-      expect(StringUtil.normalizePhoneNumber('82-70-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082 70 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082-70-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082 070 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082-070-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082 70 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('082-70-1234-5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82 070 1234 5678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82-070-1234-5678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('827012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('8207012345678')).toBe('07012345678');
+      // expect(StringUtil.normalizeKoreaPhoneNumber('82 70 1234 5678')).toBe('07012345678');
+      expect(StringUtil.normalizeKoreaPhoneNumber('82-70-1234-5678')).toBe('07012345678');
     });
 
-    it('should normalize phone number even if it does not belong to domestic number type', () => {
-      expect(StringUtil.normalizePhoneNumber('+1-123-456-8900')).toBe('11234568900');
-      expect(StringUtil.normalizePhoneNumber('88123456789')).toBe('88123456789');
-      expect(StringUtil.normalizePhoneNumber('83-1234-5678')).toBe('8312345678');
-      expect(StringUtil.normalizePhoneNumber('+49 1234 56789')).toBe('49123456789');
-    });
+    // it('should normalize phone number even if it does not belong to domestic number type', () => {
+    //   expect(StringUtil.normalizeKoreaPhoneNumber('+1-123-456-8900')).toBe('11234568900');
+    //   expect(StringUtil.normalizeKoreaPhoneNumber('88123456789')).toBe('88123456789');
+    //   expect(StringUtil.normalizeKoreaPhoneNumber('83-1234-5678')).toBe('8312345678');
+    //   expect(StringUtil.normalizeKoreaPhoneNumber('+49 1234 56789')).toBe('49123456789');
+    // });
   });
 
   describe('validatePhoneNumber', () => {
-    it('should validate phone number', () => {
-      expect(StringUtil.isValidPhoneNumber('01012345678')).toBe(true);
-      expect(StringUtil.isValidPhoneNumber('07012345678')).toBe(true);
-      expect(StringUtil.isValidPhoneNumber('1012345678')).toBe(false);
-      expect(StringUtil.isValidPhoneNumber('04412345678')).toBe(false);
-      expect(StringUtil.isValidPhoneNumber('010123456789')).toBe(false);
+    const isValidKoreaPhoneNumber = StringUtil.isValidKoreaPhoneNumber;
+    it('should return true for a Korea phone number', () => {
+      expect(isValidKoreaPhoneNumber('01012345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('821012345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('010-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('+82-10-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82-10-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('0212345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82212345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('02-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('+82-2-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82-2-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('021234567')).toBe(true);
+      expect(isValidKoreaPhoneNumber('8221234567')).toBe(true);
+      expect(isValidKoreaPhoneNumber('02-123-4567')).toBe(true);
+      expect(isValidKoreaPhoneNumber('+82-2-123-4567')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82-2-123-4567')).toBe(true);
+      expect(isValidKoreaPhoneNumber('04412345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('824412345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('044-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('+82-44-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82-44-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('07012345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('827012345678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('070-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('+82-70-1234-5678')).toBe(true);
+      expect(isValidKoreaPhoneNumber('82-70-1234-5678')).toBe(true);
+    });
+    it('should return false for a wrong string', () => {
+      expect(isValidKoreaPhoneNumber('01012345678a')).toBe(false);
+      expect(isValidKoreaPhoneNumber('1012345678')).toBe(false);
+      expect(isValidKoreaPhoneNumber('010123456789')).toBe(false);
+      expect(isValidKoreaPhoneNumber('02!1234-5678')).toBe(false);
+      expect(isValidKoreaPhoneNumber('031-12-3456')).toBe(false);
+      expect(isValidKoreaPhoneNumber('051-1234-567')).toBe(false);
+      expect(isValidKoreaPhoneNumber('+82-090-1234-5678')).toBe(false);
+      expect(isValidKoreaPhoneNumber('+82-010-1234-5678')).toBe(false);
+      expect(isValidKoreaPhoneNumber('+81-10-1234-5678')).toBe(false);
     });
   });
 

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,7 +1,36 @@
 import Mustache from 'mustache';
 import type { Tag, TemplateOpts } from './string-util.interface';
 
-const DOMESTIC_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
+const KOREAN_PHONE_NUMBER_REGEXP = /^0[1,7]\d{9}$/;
+const KOREA_COUNTRY_NUMBER_REGEXP = /\+?82-?/;
+const KOREA_EXCHANGE_NUMBERS = [
+  '10',
+  '11',
+  '12',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '2',
+  '31',
+  '32',
+  '33',
+  '41',
+  '42',
+  '43',
+  '44',
+  '51',
+  '52',
+  '53',
+  '54',
+  '55',
+  '61',
+  '62',
+  '63',
+  '64',
+  '70',
+].join('|');
 
 export namespace StringUtil {
   export function midMask(str: string, startIndex: number, length: number, maskChar = '*'): string {
@@ -27,8 +56,24 @@ export namespace StringUtil {
     return Mustache.render(template, view, partial, customTag);
   }
 
+  export function isValidKoreaPhoneNumber(str: string): boolean {
+    const regexp = new RegExp(
+      `^(${KOREA_COUNTRY_NUMBER_REGEXP.source}|0)(${KOREA_EXCHANGE_NUMBERS})-?\\d{3,4}-?\\d{4}$`
+    );
+    return regexp.test(str);
+  }
+
+  export function normalizeKoreaPhoneNumber(str: string): string {
+    if (!isValidKoreaPhoneNumber(str)) {
+      throw new Error('Not a valid Korea phone number');
+    }
+
+    return str.replace(KOREA_COUNTRY_NUMBER_REGEXP, '0').replace(/-/g, '');
+  }
+
+  /** @deprecated */
   export function normalizePhoneNumber(str: string): string {
-    if (DOMESTIC_PHONE_NUMBER_REGEXP.test(str)) {
+    if (KOREAN_PHONE_NUMBER_REGEXP.test(str)) {
       return str;
     }
 
@@ -41,8 +86,9 @@ export namespace StringUtil {
     return trimmedPhoneNumber;
   }
 
+  /** @deprecated */
   export function isValidPhoneNumber(str: string): boolean {
-    return DOMESTIC_PHONE_NUMBER_REGEXP.test(str);
+    return KOREAN_PHONE_NUMBER_REGEXP.test(str);
   }
 
   export function isValidEmail(str: string): boolean {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
StringUtil의 isValidPhoneNumber, normalizePhoneNumber 두 함수는 한국의 특정형태 전화번호만 다루도록 되어있다.
좀 더 광범위한 한국 전화번호를 다루는 isValidKoreaPhoneNumber, normalizeKoreaPhoneNumber를 추가하자

## 무엇을 어떻게 변경했나요?
isValidPhoneNumber, normalizePhoneNumber는 deprecated 처리
isValidKoreaPhoneNumber, normalizeKoreaPhoneNumber 구현

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
```
입력받을 수 있는 한국 전화번호 양식은 (즉, isValidKoreaPhoneNumber() === true인 양식은)
1. +82-(앞자리 0 제외한 지역번호 혹은 이동통신번호 혹은 공통서비스번호)-(3 혹은 4자리 국번)-(4자리 개별번호)
2. (지역번호 혹은 이동통신번호 혹은 공통서비스번호)-(3 혹은 4자리 국번)-(4자리 개별번호)
형태인 것으로 제한한다

+와 -기호는 생략 가능하다

표기에 사용되는 기호는 +, -, 숫자만 사용하는 것으로 제한한다
```
https://ko.wikipedia.org/wiki/%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD%EC%9D%98_%EC%A0%84%ED%99%94%EB%B2%88%ED%98%B8_%EC%B2%B4%EA%B3%84#%ED%8A%B9%EC%88%98%EB%B2%88%ED%98%B8

## 어떻게 테스트 하셨나요?
npm run test
