### PR TITLE
feat: Add maskPrivacy function

### DIFF
--- a/src/string-util/string-util.interface.ts
+++ b/src/string-util/string-util.interface.ts
@@ -10,3 +10,9 @@ export interface TemplateOpts {
   partial?: Record<string, string>;
   customTag?: [string, string];
 }
+
+export interface MaskingOpts {
+  text: string;
+  length: number;
+  maskingStart: number;
+}

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -2,6 +2,51 @@ import { StringUtil } from './string-util';
 import { TemplateOpts } from './string-util.interface';
 
 describe('StringUtil', () => {
+  describe('maskPrivacy', () => {
+    it('should mask names except the first and last characters', () => {
+      expect(StringUtil.maskPrivacy('김이', 'name')).toBe('김*');
+      expect(StringUtil.maskPrivacy('김이박', 'name')).toBe('김*박');
+      expect(StringUtil.maskPrivacy('김이박최', 'name')).toBe('김**최');
+      expect(StringUtil.maskPrivacy('김이박최정', 'name')).toBe('김***정');
+    });
+
+    it('should mask bank accounts from the fourth character to the last fourth character', () => {
+      const testBankAccount1 = '1234567890';
+      const testBankAccount2 = '1234567890123';
+      const testBankAccount3 = '1234567890123456';
+      const expectedMaskedBankAccount1 = '123****890';
+      const expectedMaskedBankAccount2 = '123*******123';
+      const expectedMaskedBankAccount3 = '123**********456';
+
+      expect(StringUtil.maskPrivacy(testBankAccount1, 'bankAccount')).toBe(expectedMaskedBankAccount1);
+      expect(StringUtil.maskPrivacy(testBankAccount2, 'bankAccount')).toBe(expectedMaskedBankAccount2);
+      expect(StringUtil.maskPrivacy(testBankAccount3, 'bankAccount')).toBe(expectedMaskedBankAccount3);
+    });
+
+    it('should mask emails from the third character to the character before @', () => {
+      const testEmail1 = 'test@test.com';
+      const testEmail2 = '12test@test.com';
+      const testEmail3 = '__testtesttesttest@test.com';
+      const expectedTestEmail1 = 'te**@test.com';
+      const expectedTestEmail2 = '12****@test.com';
+      const expectedTestEmail3 = '__****************@test.com';
+
+      expect(StringUtil.maskPrivacy(testEmail1, 'email')).toBe(expectedTestEmail1);
+      expect(StringUtil.maskPrivacy(testEmail2, 'email')).toBe(expectedTestEmail2);
+      expect(StringUtil.maskPrivacy(testEmail3, 'email')).toBe(expectedTestEmail3);
+    });
+
+    it('should mask phone numbers in the middle', () => {
+      const testPhone1 = '01011118888';
+      const testPhone2 = '0101118888';
+      const expectedTestPhone1 = '010****8888';
+      const expectedTestPhone2 = '010***8888';
+
+      expect(StringUtil.maskPrivacy(testPhone1, 'phone')).toBe(expectedTestPhone1);
+      expect(StringUtil.maskPrivacy(testPhone2, 'phone')).toBe(expectedTestPhone2);
+    });
+  });
+
   describe('midMask', () => {
     it('should mask phone number', () => {
       const phone1 = '010-0000-0000';

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -3,25 +3,48 @@ import { TemplateOpts } from './string-util.interface';
 
 describe('StringUtil', () => {
   describe('maskPrivacy', () => {
+    it('should return original parameter when nothing is to be masked', () => {
+      expect(StringUtil.maskPrivacy('', 'address')).toBe('');
+      expect(StringUtil.maskPrivacy('', 'bankAccount')).toBe('');
+      expect(StringUtil.maskPrivacy('', 'email')).toBe('');
+      expect(StringUtil.maskPrivacy('', 'name')).toBe('');
+      expect(StringUtil.maskPrivacy('', 'phone')).toBe('');
+    });
+
     it('should mask names except the first and last characters', () => {
-      expect(StringUtil.maskPrivacy('김', 'name')).toBe('김');
-      expect(StringUtil.maskPrivacy('김이', 'name')).toBe('김*');
-      expect(StringUtil.maskPrivacy('김이박', 'name')).toBe('김*박');
-      expect(StringUtil.maskPrivacy('김이박최', 'name')).toBe('김**최');
-      expect(StringUtil.maskPrivacy('김이박최정', 'name')).toBe('김***정');
+      const testName1 = '김';
+      const testName2 = '😆';
+      const testName3 = 'John Doe';
+      const testName4 = '김이';
+      const testName5 = '김이박';
+      const testName6 = '김이박최';
+      const testName7 = '김이박최정';
+      const testName8 = 'John Doe 김이박';
+
+      expect(StringUtil.maskPrivacy(testName1, 'name')).toBe(testName1);
+      expect(StringUtil.maskPrivacy(testName2, 'name')).toBe(testName2);
+      expect(StringUtil.maskPrivacy(testName3, 'name')).toBe('J******e');
+      expect(StringUtil.maskPrivacy(testName4, 'name')).toBe('김*');
+      expect(StringUtil.maskPrivacy(testName5, 'name')).toBe('김*박');
+      expect(StringUtil.maskPrivacy(testName6, 'name')).toBe('김**최');
+      expect(StringUtil.maskPrivacy(testName7, 'name')).toBe('김***정');
+      expect(StringUtil.maskPrivacy(testName8, 'name')).toBe('J**********박');
     });
 
     it('should mask bank accounts from the fourth character to the last fourth character', () => {
-      const testBankAccount1 = '1234567890';
-      const testBankAccount2 = '1234567890123';
-      const testBankAccount3 = '1234567890123456';
-      const expectedMaskedBankAccount1 = '123****890';
-      const expectedMaskedBankAccount2 = '123*******123';
-      const expectedMaskedBankAccount3 = '123**********456';
+      const testBankAccount1 = '123456';
+      const testBankAccount2 = '1234567890';
+      const testBankAccount3 = '1234567890123';
+      const testBankAccount4 = '1234567890123456';
+      const expectedMaskedBankAccount1 = '123456';
+      const expectedMaskedBankAccount2 = '123****890';
+      const expectedMaskedBankAccount3 = '123*******123';
+      const expectedMaskedBankAccount4 = '123**********456';
 
       expect(StringUtil.maskPrivacy(testBankAccount1, 'bankAccount')).toBe(expectedMaskedBankAccount1);
       expect(StringUtil.maskPrivacy(testBankAccount2, 'bankAccount')).toBe(expectedMaskedBankAccount2);
       expect(StringUtil.maskPrivacy(testBankAccount3, 'bankAccount')).toBe(expectedMaskedBankAccount3);
+      expect(StringUtil.maskPrivacy(testBankAccount4, 'bankAccount')).toBe(expectedMaskedBankAccount4);
     });
 
     it('should mask emails from the third character to the character before @', () => {
@@ -43,11 +66,55 @@ describe('StringUtil', () => {
     it('should mask phone numbers in the middle', () => {
       const testPhone1 = '01011118888';
       const testPhone2 = '0101118888';
+      const testPhone3 = '010-1111-8888';
+      const testPhone4 = '+1 111 8888';
+      const testPhone5 = '+1 111-1111-11111';
       const expectedTestPhone1 = '010****8888';
       const expectedTestPhone2 = '010***8888';
+      const expectedTestPhone3 = '010******8888';
+      const expectedTestPhone4 = '+1*****8888';
+      const expectedTestPhone5 = '+1 111******11111';
 
       expect(StringUtil.maskPrivacy(testPhone1, 'phone')).toBe(expectedTestPhone1);
       expect(StringUtil.maskPrivacy(testPhone2, 'phone')).toBe(expectedTestPhone2);
+      expect(StringUtil.maskPrivacy(testPhone3, 'phone')).toBe(expectedTestPhone3);
+      expect(StringUtil.maskPrivacy(testPhone4, 'phone')).toBe(expectedTestPhone4);
+      expect(StringUtil.maskPrivacy(testPhone5, 'phone')).toBe(expectedTestPhone5);
+    });
+
+    it('should mask Korean address', () => {
+      const testAddress1 = '강원 원주시 학성동 12아파트';
+      const testAddress2 = '서울특별시 강남구 역삼동 12번지 34빌딩';
+      const testAddress3 = '서울 영등포구 양평동5가 12-3 456호';
+      const testAddress4 = '충북 보은군 회남면 신곡리 산12-3';
+      const testAddress5 = '세종 어진동 123 45호';
+      const testAddress6 = '세종특별자치시 한누리대로 1234';
+      const testAddress7 = '서울 강남구 강남대로 123길 45 67빌딩';
+      const testAddress8 = '경남 양산시 물금읍 가촌서로 12345';
+      const testAddress9 = '전북 남원시 사매면 서도길 1234';
+      const testAddress10 = '부산 해운대구 달맞이길117번가길 123-45';
+
+      const expectedTestAddress1 = testAddress1.replace(' 12아파트', '*'.repeat(' 12아파트'.length));
+      const expectedTestAddress2 = testAddress2.replace(' 12번지 34빌딩', '*'.repeat(' 12번지 34빌딩'.length));
+      const expectedTestAddress3 = testAddress3.replace(' 12-3 456호', '*'.repeat(' 12-3 456호'.length));
+      const expectedTestAddress4 = testAddress4.replace(' 신곡리 산12-3', '*'.repeat(' 신곡리 산12-3'.length));
+      const expectedTestAddress5 = testAddress5.replace(' 123 45호', '*'.repeat(' 123 45호'.length));
+      const expectedTestAddress6 = testAddress6.replace(' 1234', '*'.repeat(' 1234'.length));
+      const expectedTestAddress7 = testAddress7.replace(' 123길 45 67빌딩', '*'.repeat(' 123길 45 67빌딩'.length));
+      const expectedTestAddress8 = testAddress8.replace(' 12345', '*'.repeat(' 12345'.length));
+      const expectedTestAddress9 = testAddress9.replace(' 1234', '*'.repeat(' 1234'.length));
+      const expectedTestAddress10 = testAddress10.replace(' 123-45', '*'.repeat(' 123-45'.length));
+
+      expect(StringUtil.maskPrivacy(testAddress1, 'address')).toBe(expectedTestAddress1);
+      expect(StringUtil.maskPrivacy(testAddress2, 'address')).toBe(expectedTestAddress2);
+      expect(StringUtil.maskPrivacy(testAddress3, 'address')).toBe(expectedTestAddress3);
+      expect(StringUtil.maskPrivacy(testAddress4, 'address')).toBe(expectedTestAddress4);
+      expect(StringUtil.maskPrivacy(testAddress5, 'address')).toBe(expectedTestAddress5);
+      expect(StringUtil.maskPrivacy(testAddress6, 'address')).toBe(expectedTestAddress6);
+      expect(StringUtil.maskPrivacy(testAddress7, 'address')).toBe(expectedTestAddress7);
+      expect(StringUtil.maskPrivacy(testAddress8, 'address')).toBe(expectedTestAddress8);
+      expect(StringUtil.maskPrivacy(testAddress9, 'address')).toBe(expectedTestAddress9);
+      expect(StringUtil.maskPrivacy(testAddress10, 'address')).toBe(expectedTestAddress10);
     });
   });
 

--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -4,6 +4,7 @@ import { TemplateOpts } from './string-util.interface';
 describe('StringUtil', () => {
   describe('maskPrivacy', () => {
     it('should mask names except the first and last characters', () => {
+      expect(StringUtil.maskPrivacy('김', 'name')).toBe('김');
       expect(StringUtil.maskPrivacy('김이', 'name')).toBe('김*');
       expect(StringUtil.maskPrivacy('김이박', 'name')).toBe('김*박');
       expect(StringUtil.maskPrivacy('김이박최', 'name')).toBe('김**최');
@@ -27,13 +28,16 @@ describe('StringUtil', () => {
       const testEmail1 = 'test@test.com';
       const testEmail2 = '12test@test.com';
       const testEmail3 = '__testtesttesttest@test.com';
+      const testEmail4 = 'te@test.com';
       const expectedTestEmail1 = 'te**@test.com';
       const expectedTestEmail2 = '12****@test.com';
       const expectedTestEmail3 = '__****************@test.com';
+      const expectedTestEmail4 = 'te@test.com';
 
       expect(StringUtil.maskPrivacy(testEmail1, 'email')).toBe(expectedTestEmail1);
       expect(StringUtil.maskPrivacy(testEmail2, 'email')).toBe(expectedTestEmail2);
       expect(StringUtil.maskPrivacy(testEmail3, 'email')).toBe(expectedTestEmail3);
+      expect(StringUtil.maskPrivacy(testEmail4, 'email')).toBe(expectedTestEmail4);
     });
 
     it('should mask phone numbers in the middle', () => {

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -1,5 +1,6 @@
 import Mustache from 'mustache';
-import type { Tag, TemplateOpts } from './string-util.interface';
+import type { MaskingOpts, Tag, TemplateOpts } from './string-util.interface';
+import type { PrivacyType } from './string-util.type';
 
 const KOREA_COUNTRY_NUMBER_REGEXP = /^(\+?82-?|0)/;
 const KOREA_MOBILE_PREFIXES_REGEXP = /10|11|12|15|16|17|18|19/;
@@ -11,6 +12,41 @@ const KOREA_PHONE_NUMBER_REGEXP = new RegExp(
 );
 
 export namespace StringUtil {
+  export function maskPrivacy(text: string, type: PrivacyType): string {
+    function getMaskedString({ text, length, maskingStart }: MaskingOpts): string {
+      const masking = '*'.repeat(length);
+      const textSplit = [...text];
+      textSplit.splice(maskingStart, length, masking);
+      return textSplit.join('');
+    }
+
+    let start: number;
+    let end: number;
+
+    switch (type) {
+      case 'bankAccount':
+        start = 3;
+        end = text.length - 3;
+        return getMaskedString({ text, length: end - start, maskingStart: start });
+
+      case 'email':
+        start = 2;
+        end = text.indexOf('@');
+        return getMaskedString({ text, length: end - start, maskingStart: start });
+
+      case 'name':
+        start = 1;
+        end = text.length - 1;
+        return getMaskedString({ text, length: end - start || 1, maskingStart: start });
+
+      case 'phone':
+        start = 3;
+        end = text.length - 4;
+        return getMaskedString({ text, length: end - start, maskingStart: start });
+    }
+  }
+
+  /** @deprecated in favor of maskPrivacy */
   export function midMask(str: string, startIndex: number, length: number, maskChar = '*'): string {
     const strList = [...str];
     const maskingPart = maskChar.repeat(length);

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -14,6 +14,7 @@ const KOREA_PHONE_NUMBER_REGEXP = new RegExp(
 export namespace StringUtil {
   export function maskPrivacy(text: string, type: PrivacyType): string {
     function getMaskedString({ text, length, maskingStart }: MaskingOpts): string {
+      length = Math.max(0, length);
       const masking = '*'.repeat(length);
       const textSplit = [...text];
       textSplit.splice(maskingStart, length, masking);

--- a/src/string-util/string-util.type.ts
+++ b/src/string-util/string-util.type.ts
@@ -1,1 +1,1 @@
-export type PrivacyType = 'name' | 'phone' | 'email' | 'bankAccount';
+export type PrivacyType = 'name' | 'phone' | 'email' | 'bankAccount' | 'address';

--- a/src/string-util/string-util.type.ts
+++ b/src/string-util/string-util.type.ts
@@ -1,0 +1,1 @@
+export type PrivacyType = 'name' | 'phone' | 'email' | 'bankAccount';


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
개인정보 마스킹 로직 적용이 필요하다

## 무엇을 어떻게 변경했나요?
개인정보 타입별 마스킹해주는 함수 구현

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
https://fastcampus.atlassian.net/wiki/spaces/SRE/pages/1983643664/csv

이름: 앞뒤 1자리 외 마스킹 (이모지를 포함하거나 한국 이름이 아닐 수 있음)
전화번호: 중간자리 마스킹 (normalize 되지 않은 전화번호가 포함되어 있을 수 있음 `ex) 010-1234-1234`)
계좌번호: 앞뒤 3자리 외 마스킹
주소: 지번주소라면 동면읍 / 도로명주소라면 도로명 미만 마스킹
- 서울시 강남구 강남대로 111길 11로 11 -> 서울시 강남구 강남대로 xxx~
- 전북 완주군 봉동읍 둔산1로 11 -> 전북 완주군 봉동읍 둔산1로 xx
- 전북 완주군 봉동읍 둔산리 11 -> 전북 완주군 봉동읍 xxx ~
- 지번주소 중 동면읍 단위에서 '가'로 끝나는 주소도 존재 `(ex: 서울 성동구 성수동1~2가, 금호동1~3가 등)`

이메일: 앞에서 3번째 ~ '@' 전까지 마스킹

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
npm test

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="642" alt="Screen Shot 2022-04-28 at 12 04 05 PM" src="https://user-images.githubusercontent.com/63729090/165668344-ae07734c-f8c1-4d94-8d68-8d713d3acb51.png">

