### PR TITLE
normalizeKoreaPhoneNumber에서 fallback이 있으면 throw를 하지 않도록 하자

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -130,7 +130,6 @@ describe('StringUtil', () => {
       expect(normalizeKoreaPhoneNumber('07012345678')).toBe(voipNumber);
       expect(normalizeKoreaPhoneNumber('070-1234-5678')).toBe(voipNumber);
     });
-
     it('should normalize phone number starting with (+)82 or (+)082', () => {
       expect(normalizeKoreaPhoneNumber('+821012345678')).toBe(mobileNumber);
       expect(normalizeKoreaPhoneNumber('+82-10-1234-5678')).toBe(mobileNumber);
@@ -149,8 +148,7 @@ describe('StringUtil', () => {
       expect(normalizeKoreaPhoneNumber('827012345678')).toBe(voipNumber);
       expect(normalizeKoreaPhoneNumber('82-70-1234-5678')).toBe(voipNumber);
     });
-
-    it('should throw for the not-valid-in-Korea phone number', () => {
+    it('should throw for the not-valid-in-Korea phone number and no fallback', () => {
       expect(() => normalizeKoreaPhoneNumber('01012345678a')).toThrow();
       expect(() => normalizeKoreaPhoneNumber('1012345678')).toThrow();
       expect(() => normalizeKoreaPhoneNumber('010123456789')).toThrow();
@@ -161,6 +159,9 @@ describe('StringUtil', () => {
       expect(() => normalizeKoreaPhoneNumber('+82-090-1234-5678')).toThrow();
       expect(() => normalizeKoreaPhoneNumber('+82-010-1234-5678')).toThrow();
       expect(() => normalizeKoreaPhoneNumber('+1-10-1234-5678')).toThrow();
+    });
+    it('should return fallback for the not-valid-in-Korea phone number', () => {
+      expect(normalizeKoreaPhoneNumber('01012345678a', 'fallback')).toBe('fallback');
     });
   });
 

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -38,11 +38,15 @@ export namespace StringUtil {
     return KOREA_PHONE_NUMBER_REGEXP.test(str);
   }
 
-  export function normalizeKoreaPhoneNumber(str: string): string {
+  export function normalizeKoreaPhoneNumber(str: string, fallback?: unknown): string {
     const trimmedStr = str.trim();
 
     if (!isValidKoreaPhoneNumber(trimmedStr)) {
-      return trimmedStr;
+      if (!fallback) {
+        throw new Error('Not a valid Korea phone number');
+      } else {
+        return typeof fallback === 'function' ? fallback() : typeof fallback === 'string' ? fallback.trim() : fallback;
+      }
     }
 
     return trimmedStr.replace(KOREA_COUNTRY_NUMBER_REGEXP, '0').replace(/-/g, '');

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -42,7 +42,7 @@ export namespace StringUtil {
     const trimmedStr = str.trim();
 
     if (!isValidKoreaPhoneNumber(trimmedStr)) {
-      throw new Error('Not a valid Korea phone number');
+      return trimmedStr;
     }
 
     return trimmedStr.replace(KOREA_COUNTRY_NUMBER_REGEXP, '0').replace(/-/g, '');

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -44,9 +44,9 @@ export namespace StringUtil {
     if (!isValidKoreaPhoneNumber(trimmedStr)) {
       if (!fallback) {
         throw new Error('Not a valid Korea phone number');
-      } else {
-        return typeof fallback === 'function' ? fallback() : typeof fallback === 'string' ? fallback.trim() : fallback;
       }
+
+      return typeof fallback === 'function' ? fallback() : fallback;
     }
 
     return trimmedStr.replace(KOREA_COUNTRY_NUMBER_REGEXP, '0').replace(/-/g, '');


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 무엇을 어떻게 변경했나요?
허용 가능한 한국 전화번호 형태가 아니면 기본적으로 throw error를 하되
fallback이 존재하면 fallback을 반환 하도록 수정

## 어떻게 테스트 하셨나요?
npm run test
