### PR TITLE
deepClone시 constructor가 undefined면 new Object()로 생성

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -147,7 +147,7 @@ describe('ObjectUtil', () => {
       const float64Array = new Float64Array(buf);
       float64Array[0] = 0.5;
       float64Array[1] = 1.5;
-      const clonedBuf = deepClone(buf);
+      const clonedBuf = deepClone<ArrayBuffer>(buf);
       const clonedFloat64Array = new Float64Array(clonedBuf);
       expect(clonedFloat64Array).not.toBe(float64Array);
       expect(clonedFloat64Array).toEqual(float64Array);

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -65,7 +65,7 @@ export namespace ObjectUtil {
       return obj;
     }
 
-    const clonedObj = new constructor();
+    const clonedObj = constructor ? new constructor() : (new Object() as Type);
     getAllPropertyKeys(obj).forEach((key) => {
       let value;
       if (obj[key] instanceof Object) {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
deepClone 대상의 constructor가 undefined인 경우가 있다.
현재의 deepClone에서는 대상의 constructor를 이용해 결과물을 생성하기 때문에 이런 경우 오류가 발생한다.

## 무엇을 어떻게 변경했나요?
constructor가 undefined면 new Object()로 deepClone 결과물을 생성한다.

## 어떻게 테스트 하셨나요?
npm run test
