### PR TITLE
nullish한 값을 가진 key가 존재할 때 key가 삭제되지 않는 버그

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -260,12 +260,17 @@ describe('ObjectUtil', () => {
       const testObj1 = {};
       const testObj2 = new Map();
       const testObj3 = new Set();
-      expect(ObjectUtil.omit(testObj1, ['foo'])).toEqual({});
-      expect(ObjectUtil.omit(testObj1, ['foo'])).not.toBe(testObj1);
-      expect(ObjectUtil.omit(testObj2, ['foo'])).toEqual(new Map());
-      expect(ObjectUtil.omit(testObj2, ['foo'])).not.toBe(testObj2);
-      expect(ObjectUtil.omit(testObj3, ['foo'])).toEqual(new Set());
-      expect(ObjectUtil.omit(testObj3, ['foo'])).not.toBe(testObj3);
+      expect(omit(testObj1, ['foo'])).toEqual({});
+      expect(omit(testObj1, ['foo'])).not.toBe(testObj1);
+      expect(omit(testObj2, ['foo'])).toEqual(new Map());
+      expect(omit(testObj2, ['foo'])).not.toBe(testObj2);
+      expect(omit(testObj3, ['foo'])).toEqual(new Set());
+      expect(omit(testObj3, ['foo'])).not.toBe(testObj3);
+    });
+
+    it('should return obj with deleted keys with undefined value', () => {
+      const testObj = { foo: undefined };
+      expect(omit(testObj, ['foo'])).toEqual({});
     });
   });
 

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -110,19 +110,24 @@ export namespace ObjectUtil {
 
   export function omit(obj: Readonly<ObjectType>, omitKeys: Readonly<ObjectKeyType[]>): ObjectType {
     function omitObject(obj: ObjectType, omitKeys: Readonly<ObjectKeyType[]>): ObjectType {
+      const objKeys = getAllPropertyKeys(obj);
       omitKeys.forEach((omitKey) => {
-        const nestedKeys: ObjectKeyType[] = [omitKey];
+        const nestedKeys: ObjectKeyType[] = [];
 
         if (typeof omitKey === 'string') {
-          const index = omitKey.indexOf('.');
+          const index = omitKey.includes('.') ? omitKey.indexOf('.') : omitKey.length;
+          nestedKeys.push(omitKey.substring(0, index));
 
-          if (index >= 0) {
-            nestedKeys[0] = omitKey.substring(0, index);
+          if (index < omitKey.length - 1) {
             nestedKeys.push(omitKey.substring(index + 1, omitKey.length));
           }
+        } else if (typeof omitKey === 'number') {
+          nestedKeys.push(omitKey.toString());
+        } else {
+          nestedKeys.push(omitKey);
         }
 
-        if (!isNullish(obj[nestedKeys[0]])) {
+        if (objKeys.includes(nestedKeys[0])) {
           if (nestedKeys.length > 1) {
             obj[nestedKeys[0]] = omitObject(obj[nestedKeys[0]], [nestedKeys[1]]);
           } else {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
omit 대상 객체의 특정 키에 대한 값이 nullish한 경우 해당 key가 삭제되지 않는다

## 무엇을 어떻게 변경했나요?
값의 nullish 여부를 떠나 키가 존재하면 삭제하도록 수정
테스트 케이스 추가

## 어떻게 테스트 하셨나요?
npm run test
