### PR TITLE
fix: set default value of str to empty string in splitTags

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -391,6 +391,9 @@ describe('StringUtil', () => {
     it('should return empty array when empty string is given', () => {
       expect(StringUtil.splitTags('')).toEqual([]);
     });
+    it('should return empty array when undefined is given', () => {
+      expect(StringUtil.splitTags(undefined)).toEqual([]);
+    });
   });
 
   describe('split', () => {

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -156,7 +156,7 @@ export namespace StringUtil {
     return EMAIL_REGEXP.test(str);
   }
 
-  export function splitTags(str: string, separator = ','): Tag[] {
+  export function splitTags(str = '', separator = ','): Tag[] {
     return split(str, separator).map((text) => {
       return { text };
     });


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 무엇을 어떻게 변경했나요?
splitTags의 str 기본값을 빈 스트링으로 설정하여 입력값이 undefined일 경우 발생하는 예외를 보완

## 어떻게 테스트 하셨나요?
스모크 테스트