### PR TITLE
Revert "fix: set default value of str to empty string in splitTags"

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -391,9 +391,6 @@ describe('StringUtil', () => {
     it('should return empty array when empty string is given', () => {
       expect(StringUtil.splitTags('')).toEqual([]);
     });
-    it('should return empty array when undefined is given', () => {
-      expect(StringUtil.splitTags(undefined)).toEqual([]);
-    });
   });
 
   describe('split', () => {

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -156,7 +156,7 @@ export namespace StringUtil {
     return EMAIL_REGEXP.test(str);
   }
 
-  export function splitTags(str = '', separator = ','): Tag[] {
+  export function splitTags(str: string, separator = ','): Tag[] {
     return split(str, separator).map((text) => {
       return { text };
     });


### PR DESCRIPTION
This reverts commit d160402021726ca231107439d49597d2448c0a11.

## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 무엇을 어떻게 변경했나요?
#136 을 리버트 합니다.

## 어떻게 테스트 하셨나요?
휴먼 아이
