### PR TITLE
fix: isEmpty의 object 체크를 typeof로 변경

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -54,6 +54,10 @@ describe('ObjectUtil', () => {
       expect(ObjectUtil.isEmpty(new Set([]))).toBe(true);
       expect(ObjectUtil.isEmpty(new Map())).toBe(true);
       expect(ObjectUtil.isEmpty(new Date('2021-10-10'))).toBe(true);
+      const obj = Object.create(null);
+      expect(ObjectUtil.isEmpty(obj)).toBe(true);
+      obj['id'] = 1;
+      expect(ObjectUtil.isEmpty(obj)).toBe(false);
     });
     it('should return false', () => {
       expect(ObjectUtil.isEmpty(['foo'])).toBe(false);

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -22,11 +22,13 @@ export namespace ObjectUtil {
   }
 
   export function isEmpty(value: unknown): boolean {
+    if (value === null) {
+      return true;
+    }
     if (value instanceof Set || value instanceof Map) {
       return !value.size;
     }
-
-    if (typeof value === 'string' || value instanceof Object) {
+    if (typeof value === 'string' || typeof value === 'object') {
       return !Object.keys(value).length;
     }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 무엇을 어떻게 변경했나요?
isEmpty의 object 체크를 typeof로 변경합니다

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
`const obj = Object.create(null);` 일 경우 instanceof object로 체크가 되지 않아 잘못된 결과가 반환됩니다

## 어떻게 테스트 하셨나요?
스모크 테스트