### PR TITLE
true return과 false return 구분에 맞게 isEmpty 테스트 순서 조정

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -42,32 +42,34 @@ describe('ObjectUtil', () => {
   });
 
   describe('isEmpty', () => {
+    const isEmpty = ObjectUtil.isEmpty;
+    const obj = Object.create(null);
     it('should return true', () => {
-      expect(ObjectUtil.isEmpty(null)).toBe(true);
-      expect(ObjectUtil.isEmpty(undefined)).toBe(true);
-      expect(ObjectUtil.isEmpty(0)).toBe(true);
-      expect(ObjectUtil.isEmpty(1)).toBe(true);
-      expect(ObjectUtil.isEmpty([])).toBe(true);
-      expect(ObjectUtil.isEmpty({})).toBe(true);
-      expect(ObjectUtil.isEmpty('')).toBe(true);
-      expect(ObjectUtil.isEmpty(new Set())).toBe(true);
-      expect(ObjectUtil.isEmpty(new Set([]))).toBe(true);
-      expect(ObjectUtil.isEmpty(new Map())).toBe(true);
-      expect(ObjectUtil.isEmpty(new Date('2021-10-10'))).toBe(true);
-      const obj = Object.create(null);
-      expect(ObjectUtil.isEmpty(obj)).toBe(true);
-      obj['id'] = 1;
-      expect(ObjectUtil.isEmpty(obj)).toBe(false);
+      expect(isEmpty(null)).toBe(true);
+      expect(isEmpty(undefined)).toBe(true);
+      expect(isEmpty(0)).toBe(true);
+      expect(isEmpty(1)).toBe(true);
+      expect(isEmpty([])).toBe(true);
+      expect(isEmpty({})).toBe(true);
+      expect(isEmpty('')).toBe(true);
+      expect(isEmpty(new Set())).toBe(true);
+      expect(isEmpty(new Set([]))).toBe(true);
+      expect(isEmpty(new Map())).toBe(true);
+      expect(isEmpty(new Date('2021-10-10'))).toBe(true);
+      expect(isEmpty(obj)).toBe(true);
     });
     it('should return false', () => {
-      expect(ObjectUtil.isEmpty(['foo'])).toBe(false);
-      expect(ObjectUtil.isEmpty({ length: 0 })).toBe(false);
-      expect(ObjectUtil.isEmpty({ 1: 0 })).toBe(false);
-      expect(ObjectUtil.isEmpty({ foo: { bar: 'baz' } })).toBe(false);
-      expect(ObjectUtil.isEmpty('foo')).toBe(false);
-      expect(ObjectUtil.isEmpty(' ')).toBe(false);
-      expect(ObjectUtil.isEmpty(new Set([1, 2, 3, 'foo', {}]))).toBe(false);
-      expect(ObjectUtil.isEmpty(new Map([['foo', 1]]))).toBe(false);
+      expect(isEmpty(['foo'])).toBe(false);
+      expect(isEmpty({ length: 0 })).toBe(false);
+      expect(isEmpty({ 1: 0 })).toBe(false);
+      expect(isEmpty({ foo: { bar: 'baz' } })).toBe(false);
+      expect(isEmpty('foo')).toBe(false);
+      expect(isEmpty(' ')).toBe(false);
+      expect(isEmpty(new Set([1, 2, 3, 'foo', {}]))).toBe(false);
+      expect(isEmpty(new Map([['foo', 1]]))).toBe(false);
+      // Test for assigning to null object
+      obj['id'] = 1;
+      expect(isEmpty(obj)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
isEmpty 테스트 항목이 true return과 false return으로 구분되어있는데 새로 추가된 테스트가 이를 어겼다

## 무엇을 어떻게 변경했나요?
true return 항목에 들어있는 false return 테스트를 false return 항목으로 옮김

## 어떻게 테스트 하셨나요?
npm run test
