### PR TITLE
fix: ChangedCredentialException를 CredentialChangedException로 변경

### DIFF
--- a/src/exception/client-exception/changed-credential-exception.ts
+++ b/src/exception/client-exception/changed-credential-exception.ts
@@ -1,7 +1,7 @@
 import { ClientException } from './client-exception';
 import { HttpState } from '../../http-client';
 
-export class ChangedCredentialException extends ClientException {
+export class CredentialChangedException extends ClientException {
   constructor(message = 'CREDENTIAL_CHANGED', cause?: Error) {
     super(HttpState.UNAUTHORIZED, message, cause);
   }

--- a/src/exception/client-exception/index.ts
+++ b/src/exception/client-exception/index.ts
@@ -1,5 +1,5 @@
 export { BadRequestException } from './bad-request-exception';
-export { ChangedCredentialException } from './changed-credential-exception';
+export { CredentialChangedException } from './changed-credential-exception';
 export { ClientException } from './client-exception';
 export { ForbiddenException } from './forbidden-exception';
 export { NotFoundException } from './not-found-exception';

--- a/src/exception/exception.spec.ts
+++ b/src/exception/exception.spec.ts
@@ -1,6 +1,6 @@
 import {
   BadRequestException,
-  ChangedCredentialException,
+  CredentialChangedException,
   ClientException,
   ForbiddenException,
   NotFoundException,
@@ -118,8 +118,8 @@ describe('UnauthorizedException', () => {
 });
 describe('CredentialChangedException', () => {
   test('should have default property', () => {
-    const e = new ChangedCredentialException();
-    expect(e).toBeInstanceOf(ChangedCredentialException);
+    const e = new CredentialChangedException();
+    expect(e).toBeInstanceOf(CredentialChangedException);
     expect(e).toBeInstanceOf(ClientException);
     expect(e).toBeInstanceOf(CustomException);
     expect(e).toBeInstanceOf(Error);
@@ -128,8 +128,8 @@ describe('CredentialChangedException', () => {
     expect(e.cause).toBeUndefined();
   });
   test('should have specified property', () => {
-    const e = new ChangedCredentialException('hello', error);
-    expect(e).toBeInstanceOf(ChangedCredentialException);
+    const e = new CredentialChangedException('hello', error);
+    expect(e).toBeInstanceOf(CredentialChangedException);
     expect(e).toBeInstanceOf(ClientException);
     expect(e).toBeInstanceOf(CustomException);
     expect(e).toBeInstanceOf(Error);

--- a/src/exception/index.ts
+++ b/src/exception/index.ts
@@ -1,6 +1,6 @@
 export {
   BadRequestException,
-  ChangedCredentialException,
+  CredentialChangedException,
   ClientException,
   ForbiddenException,
   NotFoundException,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export type {
 } from './date-util';
 export {
   BadRequestException,
-  ChangedCredentialException,
+  CredentialChangedException,
   ClientException,
   CustomException,
   DataException,


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
[auth token dao] (https://github.com/day1co/redstone/blob/c29d3c678c9343f6f073b0e1ed115e068306f40e/auth/src/dao/token.js#L1)
에서  CredentialChangedException로 require 하고 있습니다.

ChangedCredentialException 보다 CredentialChangedException 네이밍이 정확 할 것 같아 수정하고자 합니다.

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
