### PR TITLE
Refactoring: isNumeric, null is  false.

### DIFF
--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -54,6 +54,9 @@ describe('NumberUtil', () => {
       expect(NumberUtil.isNumeric('sdfsdfsdfa')).toEqual(false);
       expect(NumberUtil.isNumeric('\\http')).toEqual(false);
       expect(NumberUtil.isNumeric('1.2.3')).toEqual(false);
+      expect(NumberUtil.isNumeric(undefined as any)).toEqual(false);
+      expect(NumberUtil.isNumeric(NaN as any)).toEqual(false);
+      expect(NumberUtil.isNumeric(null as any)).toEqual(false);
     });
   });
 });

--- a/src/number-util/number-util.ts
+++ b/src/number-util/number-util.ts
@@ -18,6 +18,6 @@ export namespace NumberUtil {
   }
 
   export function isNumeric(numStr: string): boolean {
-    return !isNaN(Number(numStr)) && isFinite(Number(numStr));
+    return !!numStr && !isNaN(Number(numStr)) && isFinite(Number(numStr));
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
typeScript에서는 null, NaN, undefined은 타입이 맞지않아 입력할 수가 없다.
그러나 사용하는 곳에서는 충분히 null, NaN, undefined가 입력될 수가 있다.
그 중 null인 경우 `Number(null)` 는 0으로 변환되어 숫자로 인식하기 때문에 문제가 발생한다.

## 무엇을 어떻게 변경했나요?
numStr 값이 null 인경우 false로 리턴합니다.

테스트를 위해 any를 사용하여 테스트 코드를 작성하였으나, 해당 부분은 의견 부탁드립니다. 🙏 

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
test case

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
