### PR TITLE
HttpClient에 patch request 메소드를 추가

### DIFF
--- a/src/http-client/http-client.spec.ts
+++ b/src/http-client/http-client.spec.ts
@@ -33,6 +33,12 @@ describe('HttpClient', () => {
       expect(result).toBe('put');
     });
 
+    it('Http PATCH test', async () => {
+      axios.patch = jest.fn().mockResolvedValue('patch');
+      const result = await httpClient.sendPatchRequest('/', {});
+      expect(result).toBe('patch');
+    });
+
     it('Http DELETE test', async () => {
       axios.delete = jest.fn().mockResolvedValue('delete');
       const result = await httpClient.sendDeleteRequest('/', {});

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -31,6 +31,11 @@ export class HttpClient {
     return axios.put<Type, HttpResponse<Type>>(fullUrl, data, config);
   }
 
+  sendPatchRequest<Type>(url: string, data: unknown, config?: Readonly<HttpReqConfig>): Promise<HttpResponse<Type>> {
+    const fullUrl = this.getFullUrl(url);
+    return axios.patch<Type, HttpResponse<Type>>(fullUrl, data, config);
+  }
+
   sendDeleteRequest<Type>(url: string, config?: Readonly<HttpReqConfig>): Promise<HttpResponse<Type>> {
     const fullUrl = this.getFullUrl(url);
     return axios.delete<Type, HttpResponse<Type>>(fullUrl, config);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
Http Patch request에 해당하는 메소드가 없다

## 무엇을 어떻게 변경했나요?
sendPatchRequest() 추가

## 어떻게 테스트 하셨나요?
npm run test
