### PR TITLE
Logger interface에 log 메소드 추가

### DIFF
--- a/src/logger/logger-impl/pino-logger.ts
+++ b/src/logger/logger-impl/pino-logger.ts
@@ -29,19 +29,5 @@ export class PinoLogger implements Logger {
     this.logger.error(msgTemplate, ...args);
   }
 
-  log(msgTemplate: string, ...args: unknown[]): void {
-    switch (this.logger.level) {
-      case 'error':
-        this.logger.error(msgTemplate, args);
-        break;
-      case 'warn':
-        this.logger.warn(msgTemplate, args);
-        break;
-      case 'info':
-        this.logger.info(msgTemplate, args);
-        break;
-      default:
-        this.logger.debug(msgTemplate, args);
-    }
-  }
+  log = this.debug;
 }

--- a/src/logger/logger-impl/pino-logger.ts
+++ b/src/logger/logger-impl/pino-logger.ts
@@ -28,4 +28,20 @@ export class PinoLogger implements Logger {
   error(msgTemplate: string, ...args: unknown[]): void {
     this.logger.error(msgTemplate, ...args);
   }
+
+  log(msgTemplate: string, ...args: unknown[]): void {
+    switch (this.logger.level) {
+      case 'error':
+        this.logger.error(msgTemplate, args);
+        break;
+      case 'warn':
+        this.logger.warn(msgTemplate, args);
+        break;
+      case 'info':
+        this.logger.info(msgTemplate, args);
+        break;
+      default:
+        this.logger.debug(msgTemplate, args);
+    }
+  }
 }

--- a/src/logger/logger.interface.ts
+++ b/src/logger/logger.interface.ts
@@ -6,4 +6,5 @@ export interface Logger {
   info(msgTemplate: string, ...args: unknown[]): void;
   warn(msgTemplate: string, ...args: unknown[]): void;
   error(msgTemplate: string, ...args: unknown[]): void;
+  log(msgTemplate: string, ...args: unknown[]): void;
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
NestJS에 external logger로 pebbles/logger를 적용하려 하다보니 Logger에 log() 함수가 없어서 컴파일 에러가 발생한다.
(NestJS이ㅡ LoggerService interface 참고)

## 무엇을 어떻게 변경했나요?
Logger interface에 log() 함수 추가. log()는 debug()와 동일

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
사실 NestJS에서 app.userLogger(logger); 를 컴파일 통과시키기 위해 만든 기능이고
log() 함수의 스펙은 전혀 정해진 바가 없다

## 어떻게 테스트 하셨나요?
휴먼 아이
