### PR TITLE
feat: add linear/naive merge object util methods

### DIFF
--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -196,6 +196,124 @@ describe('ObjectUtil', () => {
     });
   });
 
+  describe('naive merge', () => {
+    const { naiveMerge } = ObjectUtil;
+
+    it('merge plain object with empty target', () => {
+      const obj1 = {};
+      const obj2 = { foo: { id: 1 } };
+      const expected: ObjectType = { foo: { id: 1 } };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge plain array object with empty target', () => {
+      const obj1 = {};
+      const obj2 = { foo: [{ id: 1 }] };
+      const expected: ObjectType = { foo: [{ id: 1 }] };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge array object naively', () => {
+      const obj1 = { foo: [{ id: 1 }] };
+      const obj2 = { foo: [{ id: 2 }] };
+      const expected: ObjectType = { foo: [{ id: 1 }, { id: 2 }] };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge nested array object naively', () => {
+      const obj1 = { foo: { bar: [{ id: 3 }] } };
+      const obj2 = { foo: { bar: [{ id: 4 }] } };
+      const expected = { foo: { bar: [{ id: 3 }, { id: 4 }] } };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge multi nested array object naively', () => {
+      const obj1 = { foo: { bar: { qux: [{ id: 5 }] } } };
+      const obj2 = { foo: { bar: { qux: [{ id: 6 }] } } };
+      const expected = { foo: { bar: { qux: [{ id: 5 }, { id: 6 }] } } };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge multi nested array object for non array property', () => {
+      const obj1 = { foo: { bar: { qux: { id: 5 } } } };
+      const obj2 = { foo: { bar: { qux: [{ id: 6 }] } } };
+      const expected = { foo: { bar: { qux: [{ id: 5 }, { id: 6 }] } } };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge multi nested array object without drop anything', () => {
+      const obj1 = { foo: { bar: { qux: { id: 5 } } } };
+      const obj2 = { foo: { bar: { qux: { id: 6 } } } };
+      const expected = { foo: { bar: { qux: { id: [5, 6] } } } };
+
+      const mergedObj = naiveMerge(obj1, obj2);
+
+      expect(mergedObj).toEqual(expected);
+    });
+  });
+
+  describe('leaner merge', () => {
+    const { linearMerge } = ObjectUtil;
+
+    it('merge object linear with empty object', () => {
+      const arr1 = ['foo', 'bar', 'baz'];
+      const leaf = {};
+      const expected = { foo: { bar: { baz: {} } } };
+
+      const mergedObj = linearMerge(arr1, leaf);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge object linear with plain object ', () => {
+      const arr1 = ['foo', 'bar', 'baz'];
+      const leaf = { id: 1 };
+      const expected = { foo: { bar: { baz: leaf } } };
+
+      const mergedObj = linearMerge(arr1, { id: 1 });
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge object linear with array leaf', () => {
+      const arr1 = ['foo', 'bar', 'baz'];
+      const leaf = [1];
+      const expected = { foo: { bar: { baz: [1] } } };
+
+      const mergedObj = linearMerge(arr1, leaf);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge object linear with nested array object leaf', () => {
+      const arr1 = ['foo', 'bar', 'baz'];
+      const leaf = { id: [1] };
+      const expected = { foo: { bar: { baz: { id: [1] } } } };
+
+      const mergedObj = linearMerge(arr1, leaf);
+
+      expect(mergedObj).toEqual(expected);
+    });
+    it('merge object linear with nested primitive leaf', () => {
+      const arr1 = ['foo', 'bar', 'baz'];
+      const leaf = 'hello world';
+      const expected = { foo: { bar: { baz: 'hello world' } } };
+
+      const mergedObj = linearMerge(arr1, leaf);
+
+      expect(mergedObj).toEqual(expected);
+    });
+  });
+
   describe('omit', () => {
     const { omit } = ObjectUtil;
 

--- a/src/object-util/object-util.spec.ts
+++ b/src/object-util/object-util.spec.ts
@@ -196,6 +196,33 @@ describe('ObjectUtil', () => {
     });
   });
 
+  describe('strict merge', () => {
+    const { strictMerge } = ObjectUtil;
+    it('merge jsons and arrays', () => {
+      const obj1 = { foo: [{ bar: 2 }, { qux: 4 }] };
+      const obj2 = { foo: [{ baz: 3 }, { quux: 5 }] };
+      type SymbolKeyObj = { [key: symbol]: number };
+      const obj3: SymbolKeyObj = {};
+      const symbol = Symbol('quuz');
+      obj3[symbol] = 6;
+      const result: ObjectType = {
+        foo: [
+          { bar: 2, baz: 3 },
+          { qux: 4, quux: 5 },
+        ],
+      };
+      result[symbol] = 6;
+      expect(strictMerge(obj1, obj2, obj3)).toEqual(result);
+    });
+    it('merge objects which contain function', () => {
+      const obj1 = { foo: 1 };
+      const obj2 = { foo: (val: string) => `test ${val}` };
+      const mergedObj = strictMerge(obj1, obj2);
+      expect(mergedObj.foo('bar')).toBe('test bar');
+      expect(strictMerge(obj2, obj1)).toEqual(obj1);
+    });
+  });
+
   describe('naive merge', () => {
     const { naiveMerge } = ObjectUtil;
 

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -87,7 +87,14 @@ export namespace ObjectUtil {
     return clonedObj;
   }
 
+  /** @deprecated
+   * merge: fallback for strict merge
+   **/
   export function merge(obj: Readonly<ObjectType>, ...args: Readonly<ObjectType[]>): ObjectType {
+    return strictMerge(obj, ...args);
+  }
+
+  export function strictMerge(obj: Readonly<ObjectType>, ...args: Readonly<ObjectType[]>): ObjectType {
     const argKeysArray: ObjectKeyType[][] = [];
     const mergedObj = deepClone<ObjectType>(obj);
 
@@ -100,7 +107,7 @@ export namespace ObjectUtil {
     for (let ix = 0; ix < args.length; ix++) {
       argKeysArray[ix].forEach((key) => {
         if (isObjectTypeExceptFunction(mergedObj[key]) && isObjectTypeExceptFunction(args[ix][key])) {
-          mergedObj[key] = merge(mergedObj[key], args[ix][key]);
+          mergedObj[key] = strictMerge(mergedObj[key], args[ix][key]);
         } else {
           mergedObj[key] = args[ix][key];
         }
@@ -110,7 +117,6 @@ export namespace ObjectUtil {
     return mergedObj;
   }
 
-  // todo: 검증을 마치고 기존 merge 는 strictMerge 로 변경
   export function naiveMerge(target: Readonly<ObjectType>, source: Readonly<ObjectType>): ObjectType {
     const mergedObj = isEmpty(target) ? {} : deepClone<ObjectType>(target);
 

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -110,6 +110,43 @@ export namespace ObjectUtil {
     return mergedObj;
   }
 
+  // todo: 검증을 마치고 기존 merge 는 strictMerge 로 변경
+  export function naiveMerge(target: Readonly<ObjectType>, source: Readonly<ObjectType>): ObjectType {
+    const mergedObj = isEmpty(target) ? {} : deepClone<ObjectType>(target);
+
+    for (const [key, value] of Object.entries(source)) {
+      if (mergedObj[key]) {
+        if (Array.isArray(mergedObj[key])) {
+          if (Array.isArray(value)) {
+            mergedObj[key].push(...value);
+          } else {
+            mergedObj[key].push(value);
+          }
+        } else if (isObjectTypeExceptFunction(mergedObj[key])) {
+          if (Array.isArray(value)) {
+            mergedObj[key] = [mergedObj[key]].concat(value);
+          } else {
+            mergedObj[key] = naiveMerge(mergedObj[key], value);
+          }
+        } else {
+          mergedObj[key] = [mergedObj[key]].concat(value);
+        }
+      } else {
+        if (!Array.isArray(value) && isObjectTypeExceptFunction(value)) {
+          mergedObj[key] = naiveMerge(mergedObj[key], value);
+        } else {
+          mergedObj[key] = value;
+        }
+      }
+    }
+
+    return mergedObj;
+  }
+
+  export function linearMerge(arr: Readonly<string[]>, leaf: any): ObjectType {
+    return arr.reduceRight((acc, item) => ({ [item]: acc }), leaf);
+  }
+
   export function omit(obj: Readonly<ObjectType>, omitKeys: Readonly<ObjectKeyType[]>): ObjectType {
     function omitObject(obj: ObjectType, omitKeys: Readonly<ObjectKeyType[]>): ObjectType {
       const objKeys = getAllPropertyKeys(obj);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

조직도 구성을 위한 객체 조작을 위해 개발된 함수를 공용(pebbles)으로 이전 

- google workspace 의 조직도 구성이 `/` 문자로 구분할 수 있는 문자열로 반환되어 ldap 계정으로 저장됨
- 이 조직도의 문자열을 객체 형태로 변경하기 위한 두 개의 함수를 추가

기존 merge 함수보다 대충 다 병합해주는 deep merge 함수가 필요하여 구성하게 되었습니다.
객체의 속성을 override 하지 않고 필요하면 배열로 전환하여 모두 병합 하는 함수가 필요하게 되어 추가합니다.

기존 merge 를 strict merge 로 변경하고 fallback 을 추가해 두었습니다.

추가로 문자열 배열에 대해 nesting 된 객체를 반환하는 linear merge 함수도 추가합니다.

## 어떻게 테스트 하셨나요?

테스트 케이스 참고
