### PR TITLE
Number-util: isNumeric 공백 처리

### DIFF
--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -54,6 +54,8 @@ describe('NumberUtil', () => {
       expect(NumberUtil.isNumeric('sdfsdfsdfa')).toEqual(false);
       expect(NumberUtil.isNumeric('\\http')).toEqual(false);
       expect(NumberUtil.isNumeric('1.2.3')).toEqual(false);
+      expect(NumberUtil.isNumeric('')).toEqual(false);
+      expect(NumberUtil.isNumeric('  ')).toEqual(false);
     });
   });
 });

--- a/src/number-util/number-util.ts
+++ b/src/number-util/number-util.ts
@@ -18,6 +18,9 @@ export namespace NumberUtil {
   }
 
   export function isNumeric(numStr: string): boolean {
+    if (!numStr || numStr.trim() === '') {
+      return false;
+    }
     return !isNaN(Number(numStr)) && isFinite(Number(numStr));
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [X] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
isNumeric이 '', '  ' 같은 공백 문자열을 걸러주지 못함.
js에서 사용할 때는 null도 걸러주지 못함.

## 무엇을 어떻게 변경했나요?
공백문자열일때 false 반환하도록 변경

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
