### PR TITLE
fix isNumberic runtime error on edge case

### DIFF
--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -46,11 +46,11 @@ describe('NumberUtil', () => {
       expect(NumberUtil.isNumeric('0.1')).toEqual(true);
       expect(NumberUtil.isNumeric('-10')).toEqual(true);
       expect(NumberUtil.isNumeric('-10.1231234')).toEqual(true);
-      expect(NumberUtil.isNumeric('0xa')).toEqual(true);
     });
     it('should not equal to all', () => {
       expect(NumberUtil.isNumeric('a')).toEqual(false);
       expect(NumberUtil.isNumeric('0a')).toEqual(false);
+      expect(NumberUtil.isNumeric('0xa')).toEqual(false);
       expect(NumberUtil.isNumeric('sdfsdfsdfa')).toEqual(false);
       expect(NumberUtil.isNumeric('\\http')).toEqual(false);
       expect(NumberUtil.isNumeric('1.2.3')).toEqual(false);

--- a/src/number-util/number-util.ts
+++ b/src/number-util/number-util.ts
@@ -18,9 +18,7 @@ export namespace NumberUtil {
   }
 
   export function isNumeric(numStr: string): boolean {
-    if (!numStr || numStr.trim() === '') {
-      return false;
-    }
-    return !isNaN(Number(numStr)) && isFinite(Number(numStr));
+    const num = Number(numStr);
+    return !isNaN(num) && isFinite(num) && num === parseFloat(numStr);
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

원칙적으론 string 타입여부를 검사하는 것은 호출하는 쪽의 몫이지만...

#155 결과... 문자열이 아닌 값이 들어오면 runtime error를 발생
```
TypeError: numStr.trim is not a function ...
```

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

`Number()`와 `parseFloat()`의 edge case(`null`, `undefined`, `''` 빈문자열...) 처리가 다르다는 점을 활용.
둘의 결과가 같고 그 결과가 숫자라면 일반적인(?) 숫자라고 판단.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
