### PR TITLE
unit-converter에서 size를 없애고 value를 필수 속성으로 변경

### DIFF
--- a/src/unit-util/unit-converters/byte-unit-converter.spec.ts
+++ b/src/unit-util/unit-converters/byte-unit-converter.spec.ts
@@ -12,35 +12,35 @@ describe('byteUnitConverter', () => {
 
   describe('convert', () => {
     it('throws Error with negative size', () => {
-      const negativeSize1 = -1;
-      const negativeSize2 = -0.001;
+      const negativeValue1 = -1;
+      const negativeValue2 = -0.001;
 
       expect(() =>
-        byteUnitConverter.convert({ size: negativeSize1, inputUnit: 'bytes', outputUnit: 'megabytes' })
+        byteUnitConverter.convert({ value: negativeValue1, inputUnit: 'bytes', outputUnit: 'megabytes' })
       ).toThrow();
 
       expect(() =>
-        byteUnitConverter.convert({ size: negativeSize2, inputUnit: 'bytes', outputUnit: 'megabytes' })
+        byteUnitConverter.convert({ value: negativeValue2, inputUnit: 'bytes', outputUnit: 'megabytes' })
       ).toThrow();
     });
 
     it('should return input size as is when the convertable size is out of provided unit.', () => {
-      const size1 = 10000000000;
-      const size2 = 0.000000001;
+      const value1 = 10000000000;
+      const value2 = 0.000000001;
 
-      const test1 = byteUnitConverter.convert({ size: size1, inputUnit: 'bytes' });
-      const test2 = byteUnitConverter.convert({ size: size2, inputUnit: 'kilobytes' });
+      const test1 = byteUnitConverter.convert({ value: value1, inputUnit: 'bytes' });
+      const test2 = byteUnitConverter.convert({ value: value2, inputUnit: 'kilobytes' });
 
-      expect(test1).toBe(`${size1} ${DataSizeUnitMap.bytes}`);
-      expect(test2).toBe(`${size2.toString()} ${DataSizeUnitMap.kilobytes}`);
+      expect(test1).toBe(`${value1} ${DataSizeUnitMap.bytes}`);
+      expect(test2).toBe(`${value2.toString()} ${DataSizeUnitMap.kilobytes}`);
     });
 
     it('converts data size to a convertable unit that returns the minimum interger when outputUnit is not provided', () => {
-      const size1 = 1000;
-      const size2 = 0.000001;
-      const size3 = 100000000;
-      const size4 = 123456789;
-      const size5 = 0.0129;
+      const value1 = 1000;
+      const value2 = 0.000001;
+      const value3 = 100000000;
+      const value4 = 123456789;
+      const value5 = 0.0129;
 
       const expected1 = 1;
       const expected2 = 1;
@@ -48,11 +48,11 @@ describe('byteUnitConverter', () => {
       const expected4 = 123;
       const expected5 = 13;
 
-      const test1 = byteUnitConverter.convert({ size: size1, inputUnit: 'kilobytes' });
-      const test2 = byteUnitConverter.convert({ size: size2, inputUnit: 'megabytes' });
-      const test3 = byteUnitConverter.convert({ size: size3, inputUnit: 'bytes' });
-      const test4 = byteUnitConverter.convert({ size: size4, inputUnit: 'bytes' });
-      const test5 = byteUnitConverter.convert({ size: size5, inputUnit: 'kilobytes' });
+      const test1 = byteUnitConverter.convert({ value: value1, inputUnit: 'kilobytes' });
+      const test2 = byteUnitConverter.convert({ value: value2, inputUnit: 'megabytes' });
+      const test3 = byteUnitConverter.convert({ value: value3, inputUnit: 'bytes' });
+      const test4 = byteUnitConverter.convert({ value: value4, inputUnit: 'bytes' });
+      const test5 = byteUnitConverter.convert({ value: value5, inputUnit: 'kilobytes' });
 
       expect(getSizeNum(test1)).toBe(expected1);
       expect(getSizeNum(test2)).toBe(expected2);
@@ -62,17 +62,17 @@ describe('byteUnitConverter', () => {
     });
 
     it('converts data size from inputUnit to outputUnit', () => {
-      const size = 1000;
+      const value = 1000;
 
-      const test1 = byteUnitConverter.convert({ size, inputUnit: 'bytes', outputUnit: 'kilobytes' });
-      const test2 = byteUnitConverter.convert({ size, inputUnit: 'bytes', outputUnit: 'megabytes' });
-      const test3 = byteUnitConverter.convert({ size, inputUnit: 'megabytes', outputUnit: 'bytes' });
-      const test4 = byteUnitConverter.convert({ size, inputUnit: 'megabytes', outputUnit: 'kilobytes' });
+      const test1 = byteUnitConverter.convert({ value, inputUnit: 'bytes', outputUnit: 'kilobytes' });
+      const test2 = byteUnitConverter.convert({ value, inputUnit: 'bytes', outputUnit: 'megabytes' });
+      const test3 = byteUnitConverter.convert({ value, inputUnit: 'megabytes', outputUnit: 'bytes' });
+      const test4 = byteUnitConverter.convert({ value, inputUnit: 'megabytes', outputUnit: 'kilobytes' });
 
-      expect(getSizeNum(test1)).toBeLessThan(size);
-      expect(getSizeNum(test2)).toBeLessThan(size);
-      expect(getSizeNum(test3)).toBeGreaterThan(size);
-      expect(getSizeNum(test4)).toBeGreaterThan(size);
+      expect(getSizeNum(test1)).toBeLessThan(value);
+      expect(getSizeNum(test2)).toBeLessThan(value);
+      expect(getSizeNum(test3)).toBeGreaterThan(value);
+      expect(getSizeNum(test4)).toBeGreaterThan(value);
 
       expect(getSizeNum(test1)).toBeGreaterThan(getSizeNum(test2));
       expect(getSizeNum(test3)).toBeGreaterThan(getSizeNum(test4));

--- a/src/unit-util/unit-converters/byte-unit-converter.ts
+++ b/src/unit-util/unit-converters/byte-unit-converter.ts
@@ -1,4 +1,3 @@
-import { ObjectUtil } from '../../object-util';
 import type { ConvertOpts, UnitConverter } from '../unit-util.interface';
 import type { ByteUnitType } from './byte-unit-converter.type';
 
@@ -13,12 +12,8 @@ class ByteUnitConverter implements UnitConverter<ByteUnitType> {
     megabytes: 'MB',
   };
 
-  public convert({ size, value, inputUnit, outputUnit }: Readonly<ConvertOpts<ByteUnitType>>): string {
-    if (size && ObjectUtil.isNullish(value)) {
-      value = size;
-    }
-
-    if (ObjectUtil.isNullish(value) || value < 0) {
+  public convert({ value, inputUnit, outputUnit }: Readonly<ConvertOpts<ByteUnitType>>): string {
+    if (value < 0) {
       throw new Error('Value must be equal or greater than zero');
     }
 

--- a/src/unit-util/unit-converters/money-unit-converter.spec.ts
+++ b/src/unit-util/unit-converters/money-unit-converter.spec.ts
@@ -5,6 +5,9 @@ describe('moneyUnitConverter', () => {
     expect(moneyUnitConverter.convert({ value: 123.45, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
       '12345'
     );
+    expect(moneyUnitConverter.convert({ value: -123.45, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
+      '-12345'
+    );
     expect(moneyUnitConverter.convert({ value: 0.03, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
       '3'
     );
@@ -27,6 +30,12 @@ describe('moneyUnitConverter', () => {
     expect(moneyUnitConverter.convert({ value: 2.3, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
       '230'
     );
+    expect(moneyUnitConverter.convert({ value: 2.312, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
+      '231'
+    );
+    expect(moneyUnitConverter.convert({ value: -2.312, inputUnit: 'currency', outputUnit: 'fractionalUnit' })).toEqual(
+      '-231'
+    );
     expect(
       moneyUnitConverter.convert({ value: 1.2345e14, inputUnit: 'currency', outputUnit: 'fractionalUnit' })
     ).toEqual('12345000000000000');
@@ -38,6 +47,9 @@ describe('moneyUnitConverter', () => {
   it('exchange Fractional unit For Currency', () => {
     expect(moneyUnitConverter.convert({ value: 12345, inputUnit: 'fractionalUnit', outputUnit: 'currency' })).toEqual(
       '123.45'
+    );
+    expect(moneyUnitConverter.convert({ value: -12345, inputUnit: 'fractionalUnit', outputUnit: 'currency' })).toEqual(
+      '-123.45'
     );
     expect(moneyUnitConverter.convert({ value: 3, inputUnit: 'fractionalUnit', outputUnit: 'currency' })).toEqual(
       '0.03'
@@ -54,6 +66,9 @@ describe('moneyUnitConverter', () => {
     expect(moneyUnitConverter.convert({ value: 132.3, inputUnit: 'fractionalUnit', outputUnit: 'currency' })).toEqual(
       '1.32'
     );
+    expect(moneyUnitConverter.convert({ value: -132.3, inputUnit: 'fractionalUnit', outputUnit: 'currency' })).toEqual(
+      '-1.32'
+    );
     expect(
       moneyUnitConverter.convert({ value: 1.2345e14, inputUnit: 'fractionalUnit', outputUnit: 'currency' })
     ).toEqual('1234500000000.00');
@@ -67,11 +82,5 @@ describe('moneyUnitConverter', () => {
     expect(
       moneyUnitConverter.convert({ value: 3.0, inputUnit: 'fractionalUnit', outputUnit: 'fractionalUnit' })
     ).toEqual('3');
-  });
-
-  it('moneyUnitConverter makes exception', () => {
-    expect(() =>
-      moneyUnitConverter.convert({ value: -1, inputUnit: 'currency', outputUnit: 'fractionalUnit' })
-    ).toThrow('Value must be equal or greater than zero');
   });
 });

--- a/src/unit-util/unit-converters/money-unit-converter.ts
+++ b/src/unit-util/unit-converters/money-unit-converter.ts
@@ -1,4 +1,3 @@
-import { ObjectUtil } from '../../object-util';
 import type { ConvertOpts, UnitConverter } from '../unit-util.interface';
 import type { MoneyUnitType } from './money-unit-converter.type';
 
@@ -10,9 +9,12 @@ class MoneyUnitConverter implements UnitConverter<MoneyUnitType> {
   private fractionRatio = 100;
 
   public convert({ value, inputUnit, outputUnit }: Readonly<ConvertOpts<MoneyUnitType>>): string {
-    if (ObjectUtil.isNullish(value) || value < 0) {
-      throw new Error('Value must be equal or greater than zero');
-    }
+    // money는 환불 data가 음수이므로 음수 체크는 제거
+    // if (value < 0) {
+    //   throw new Error('Value must be equal or greater than zero');
+    // }
+    const sign = value >= 0 ? '' : '-';
+    value = Math.abs(value);
 
     if (inputUnit === outputUnit) {
       return value.toString();
@@ -44,7 +46,7 @@ class MoneyUnitConverter implements UnitConverter<MoneyUnitType> {
       result = currency + '.' + fractionalUnit.toString().padStart(2, '0');
     }
 
-    return result;
+    return sign + result;
   }
 }
 

--- a/src/unit-util/unit-util.interface.ts
+++ b/src/unit-util/unit-util.interface.ts
@@ -1,6 +1,5 @@
 export interface ConvertOpts<UNIT> {
-  size?: number;
-  value?: number;
+  value: number;
   inputUnit: UNIT;
   outputUnit?: UNIT;
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 무엇을 어떻게 변경했나요?
unit-converter interface에서 size 제거하고 value를 필수 속성으로 변경
MoneyUnitConverter에서 음수 지원 및 관련 테스트 추가

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
money의 경우 환불시 음수이기 때문에 음수를 지원해야 함

## 어떻게 테스트 하셨나요?
npm run test
