### PR TITLE
change GitHub npm package manage token of secrets to GH_TOKEN

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,12 +30,12 @@ jobs:
           cache: npm
           cache-dependency-path: './package-lock.json'
       - name: Prepare dot npmrc for private registry
-        run: echo //npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }} >> .npmrc
+        run: echo //npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }} >> .npmrc
       - name: Bootstrap
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Build Test
         run: npm run build
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,8 @@ defaults:
     shell: bash
 
 env:
-  PUSH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  PACKAGE_TOKEN: ${{ secrets.NPM_TOKEN }}
+  PUSH_TOKEN: ${{ secrets.GH_TOKEN }}
+  PACKAGE_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   check-pusher:
@@ -57,7 +57,7 @@ jobs:
       - uses: 8BitJonny/gh-get-current-pr@1.1.0
         id: PR
         with:
-          github-token: ${{ secrets.NPM_TOKEN }}
+          github-token: ${{ secrets.GH_TOKEN }}
 
   build:
     needs: ci-label-test

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,4 +16,4 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://fastcampus.atlassian.net/browse/COMMON-157

## 무엇을 어떻게 변경했나요?
깃헙에서 사용하는 npm 관련 토큰을 GH_TOKEN 으로 통일
