### PR TITLE
Feat/dateutil parse cover undefined

### DIFF
--- a/src/date-util/date-util.const.ts
+++ b/src/date-util/date-util.const.ts
@@ -1,4 +1,6 @@
 export const DATE_FORMAT = 'YYYY-MM-DD';
+export const DATE_FORMAT_DOT_TYPE = 'YYYY. MM. DD';
+export const DATE_FORMAT_US = 'MM-DD-YYYY';
 export const DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm:ssZ';
 export const DATETIME_FORMAT_WITH_MILLIS = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const LOCAL_DATETIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
@@ -11,3 +13,7 @@ export const ONE_DAY_IN_SECOND = 24 * ONE_HOUR_IN_SECOND;
 export const ONE_MINUTE_IN_MILLI = ONE_MINUTE_IN_SECOND * ONE_SECOND_IN_MILLI;
 export const ONE_HOUR_IN_MILLI = ONE_HOUR_IN_SECOND * ONE_SECOND_IN_MILLI;
 export const ONE_DAY_IN_MILLI = ONE_DAY_IN_SECOND * ONE_SECOND_IN_MILLI;
+
+export const TIMEZONE_SEOUL = 'Asia/Seoul';
+export const TIMEZONE_PST = 'PST';
+export const TIMEZONE_TOKYO = 'Asia/Tokyo';

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -45,6 +45,8 @@ describe('DateUtil', () => {
       expect(parse(testDatetimeStr5)).toEqual(new Date(testDatetimeStr5));
       expect(parse(testDatetimeStr6)).toEqual(new Date(testDatetimeStr6));
       expect(parse(testDatetimeStr8)).toEqual(new Date(testDatetimeStr8));
+      expect(parse()).toEqual(new Date());
+      expect(parse(undefined)).toEqual(new Date());
     });
     test('original input value is maintained', () => {
       const now = new Date();

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -24,7 +24,9 @@ export namespace DateUtil {
     return !isNaN(d.valueOf());
   }
 
-  export function parse(date: DateType): Date {
+  export function parse(date?: DateType): Date {
+    if (date === undefined) return new Date();
+
     if (typeof date === 'string' && date.split(/[ T]/).length === 1) {
       date = date.concat('T00:00:00.000');
     }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
fastcampus/util -> pebbles 교체중 dateutil.parse와 parse가 undefined 빈값으로 실행시 차이로 인해 정상작동하던 기능이 에러를 발생시킬수 있어서 dateUtil.parse() 실행시 new Date() 가 되도록 수정.

## 무엇을 어떻게 변경했나요?
dateUtil.parse() or dateUtil.parse(undefined) 시 new Date() 가 return 되도록 수정
## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
테스트코드
## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
