### PR TITLE
feat: Add MapUtil.groupByKey

### DIFF
--- a/src/map-util/map-util.spec.ts
+++ b/src/map-util/map-util.spec.ts
@@ -20,4 +20,37 @@ describe('MapUtil', () => {
       expect(MapUtil.get(numberMap, 'ZERO', 1)).toBe(numberMap.get('ZERO'));
     });
   });
+
+  describe('groupByKey', () => {
+    test('should group an array of objects by a specified key', () => {
+      const array = [
+        { id: 1, name: 'John' },
+        { id: 2, name: 'Jane' },
+        { id: 3, name: 'John' },
+        { id: 4, name: 'Mary' },
+        { id: 5, name: null },
+      ];
+      const expectedMap = new Map([
+        [
+          'John',
+          [
+            { id: 1, name: 'John' },
+            { id: 3, name: 'John' },
+          ],
+        ],
+        ['Jane', [{ id: 2, name: 'Jane' }]],
+        ['Mary', [{ id: 4, name: 'Mary' }]],
+        [null, [{ id: 5, name: null }]],
+      ]);
+      const result = MapUtil.groupByKey(array, 'name');
+      expect(result).toEqual(expectedMap);
+    });
+
+    test('should return an empty map when given an empty array', () => {
+      const array: any[] = [];
+      const expectedMap = new Map();
+      const result = MapUtil.groupByKey(array, 'name');
+      expect(result).toEqual(expectedMap);
+    });
+  });
 });

--- a/src/map-util/map-util.ts
+++ b/src/map-util/map-util.ts
@@ -10,4 +10,13 @@ export namespace MapUtil {
     const value = map.get(key);
     return value === undefined ? defaultValue : value;
   }
+
+  export function groupByKey<T, K extends keyof T>(array: T[], key: K): Map<T[K], T[]> {
+    return array.reduce((map, item) => {
+      const mapKey = item[key];
+      const collection = map.get(mapKey) ?? map.set(mapKey, []).get(mapKey);
+      collection.push(item);
+      return map;
+    }, new Map());
+  }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

## 무엇을 어떻게 변경했나요?

array of object `[{id: 1, ...}, ...]` 에서, 오브젝트의 키를 명시하면 Map<T[K], [T]> 를 리턴하는 함수를 추가합니다. 

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
