### PR TITLE
feat: PickWithPartial, RequiredPartialProps 추가

### DIFF
--- a/src/type-util/index.ts
+++ b/src/type-util/index.ts
@@ -1,2 +1,2 @@
 export { TypeUtil } from './type-util';
-export type { NarrowableType } from './type-util.type';
+export type { NarrowableType, PickWithPartial, RequiredPartialProps } from './type-util.type';

--- a/src/type-util/type-util.spec.ts
+++ b/src/type-util/type-util.spec.ts
@@ -1,4 +1,5 @@
 import { TypeUtil } from './type-util';
+import type { PickWithPartial, RequiredPartialProps } from './type-util.type';
 
 describe('TypeUtil', () => {
   describe('makeLiteralTypeList', () => {
@@ -7,6 +8,38 @@ describe('TypeUtil', () => {
       expect(makeLiteralTypeList('foo', 'bar', 'baz', 'qux', 'quux')).toEqual(['foo', 'bar', 'baz', 'qux', 'quux']);
       expect(makeLiteralTypeList(1, 3, 2, 4, 5)).toEqual([1, 3, 2, 4, 5]);
       expect(makeLiteralTypeList('foo', 1, 'bar', 2, undefined)).toEqual(['foo', 1, 'bar', 2, undefined]);
+    });
+  });
+
+  describe('PickWithPartial', () => {
+    it('should return ok', () => {
+      interface MockInterface {
+        prop1: number;
+        prop2: string;
+        prop3: boolean;
+      }
+      const implementedObj1: PickWithPartial<MockInterface, 'prop1'> = { prop1: 1 };
+      const implementedObj2: PickWithPartial<MockInterface, 'prop1' | 'prop2'> = { prop1: 2, prop2: 'string' };
+      expect(implementedObj1).toHaveProperty('prop1');
+      expect(implementedObj2).not.toHaveProperty('prop3');
+    });
+  });
+
+  describe('RequiredPartialProps', () => {
+    it('should return ok', () => {
+      interface MockInterface {
+        prop1: number;
+        prop2?: string;
+        prop3?: boolean;
+      }
+      const implementedObj1: RequiredPartialProps<MockInterface, 'prop2'> = { prop1: 1, prop2: 'hello' };
+      const implementedObj2: RequiredPartialProps<MockInterface, 'prop2' | 'prop3'> = {
+        prop1: 2,
+        prop2: 'world',
+        prop3: true,
+      };
+      expect(implementedObj1).toHaveProperty('prop2');
+      expect(implementedObj2).toHaveProperty('prop3');
     });
   });
 });

--- a/src/type-util/type-util.type.ts
+++ b/src/type-util/type-util.type.ts
@@ -1,1 +1,9 @@
 export type NarrowableType = string | number | undefined;
+
+// make required type of properties to optional
+export type PickWithPartial<T, K extends keyof T> = Pick<T, K> & Partial<T>;
+
+// make optional properties to required type
+export type RequiredPartialProps<T, C extends keyof T> = T & {
+  [K in C]-?: T[K];
+};


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
- 인터페이스의 특정 속성만 Pick 또는 Omit 하고 나머지 속성은 Partial 할 수 있다면, 더 자유롭게 타입/인터페이스를 사용가능할 것 같습니다.
- 이런 타입이 정말 유용할지... 아주 특별한 상황(edge case)에서만 쓰이는건가 싶어서... 일단 PR 만들어보았습니다.
- 네이밍이 한참 부족합니다. 필요한지 여부를 판단해주시고, 그 다음으로 네이밍에 대해 의견주시면 감사하겠습니다 🙇‍♂️

## 무엇을 어떻게 변경했나요?
- 전체 속성중 일부 속성만 Pick, 나머진 Partial이 적용된 PickWithPartial 을 추가합니다.
- 전체 속성중 Optional 속성의 타입을 Required로 받도록 하는 RequiredPartialProps 을 추가합니다.

## 어떻게 테스트 하셨나요?
타입이다보니 테스트 코드를 어떻게 작성해야하나 싶어 일단 해당 타입을 어떻게 사용할 수 있는지 보여주기 위한 목적으로 타입 단언을 사용한 테스트 코드를 추가하였습니다.

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="75%" alt="Screenshot 2023-06-13 at 1 36 58 PM" src="https://github.com/day1co/pebbles/assets/33862991/de2de43f-8a93-4991-8d7f-5f7ec818f884">
