### PR TITLE
feat: Add fromNow()

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm run build",
     "serve": "echo no serve",
     "start": "npm run serve",
-    "test": "jest --coverage --detectOpenHandles --forceExit --ci --silent --runInBand",
+    "test": "jest --coverage --verbose",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/src/date-util/date-util.interface.ts
+++ b/src/date-util/date-util.interface.ts
@@ -24,3 +24,13 @@ export interface LocalDateTimeFormatOpts {
   locale: LocaleType;
   formatStyle: 'long' | '2-digit';
 }
+
+export interface TimeAnnotationSet {
+  SSS: string;
+  s: string;
+  m: string;
+  H: string;
+  D: string;
+  M: string;
+  Y: string;
+}

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -444,4 +444,68 @@ describe('DateUtil', () => {
       expect(durationTo('09:60:50')).toEqual(0);
     });
   });
+
+  describe('fromNow', () => {
+    const fromNow = DateUtil.fromNow;
+
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2020-01-01')); // 00:00:00Z
+    });
+    afterAll(() => {
+      jest.clearAllTimers();
+    });
+
+    it('should return year diff from now', () => {
+      expect(fromNow(new Date('2021-01-01'))).toEqual('1년');
+      expect(fromNow(new Date('2019-01-01'))).toEqual('1년');
+      expect(fromNow(new Date('2022-01-01'))).toEqual('2년');
+      expect(fromNow(new Date('2018-01-01'))).toEqual('2년');
+
+      expect(fromNow(new Date('2021-12-31'))).toEqual('1년');
+      expect(fromNow(new Date('2019-12-31'))).not.toEqual('1년');
+      expect(fromNow(new Date('2022-12-31'))).toEqual('2년');
+      expect(fromNow(new Date('2018-12-31'))).not.toEqual('2년');
+    });
+    it('should return month diff from now', () => {
+      expect(fromNow(new Date('2020-12-01'))).toEqual('11달');
+      expect(fromNow(new Date('2020-12-31'))).toEqual('11달');
+      expect(fromNow(new Date('2020-02-01'))).toEqual('1달');
+      expect(fromNow(new Date('2020-02-28'))).toEqual('1달');
+      expect(fromNow(new Date('2019-12-01'))).toEqual('1달');
+      expect(fromNow(new Date('2019-12-02'))).not.toEqual('1달');
+      expect(fromNow(new Date('2019-11-02'))).toEqual('2달');
+      expect(fromNow(new Date('2019-11-30'))).toEqual('2달');
+      expect(fromNow(new Date('2019-02-01'))).toEqual('11달');
+      expect(fromNow(new Date('2019-02-02'))).toEqual('11달');
+    });
+    it('should return day diff from now', () => {
+      expect(fromNow(new Date('2020-01-02'))).toEqual('1일');
+      expect(fromNow(new Date('2020-01-31'))).toEqual('30일');
+      expect(fromNow(new Date('2019-12-31'))).toEqual('1일');
+      expect(fromNow(new Date('2019-12-02'))).toEqual('30일');
+    });
+    it('should return hour diff from now', () => {
+      expect(fromNow(new Date('2020-01-01 01:00:00Z'))).toEqual('1시간');
+      expect(fromNow(new Date('2020-01-01 23:00:00Z'))).toEqual('23시간');
+      expect(fromNow(new Date('2019-12-31 23:00:00Z'))).toEqual('1시간');
+      expect(fromNow(new Date('2019-12-31 01:00:00Z'))).toEqual('23시간');
+    });
+    it('should return minute diff from now', () => {
+      expect(fromNow(new Date('2020-01-01 00:59:00Z'))).toEqual('59분');
+      expect(fromNow(new Date('2020-01-01 00:01:00Z'))).toEqual('1분');
+      expect(fromNow(new Date('2019-12-31 23:01:00Z'))).toEqual('59분');
+      expect(fromNow(new Date('2019-12-31 23:59:00Z'))).toEqual('1분');
+    });
+    it('should return second diff from now', () => {
+      expect(fromNow(new Date('2020-01-01 00:00:59Z'))).toEqual('59초');
+      expect(fromNow(new Date('2020-01-01 00:00:01Z'))).toEqual('1초');
+      expect(fromNow(new Date('2019-12-31 23:59:01Z'))).toEqual('59초');
+      expect(fromNow(new Date('2019-12-31 23:59:59Z'))).toEqual('1초');
+    });
+    it('should return just now', () => {
+      expect(fromNow(new Date())).toEqual('금방');
+      expect(fromNow(new Date('2020-01-01 00:00:00.001Z'))).toEqual('금방');
+      expect(fromNow(new Date('2020-01-01 00:00:00.999Z'))).toEqual('금방');
+    });
+  });
 });

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -455,7 +455,7 @@ describe('DateUtil', () => {
       jest.clearAllTimers();
     });
 
-    it('should return year diff from now', () => {
+    it('should return year diff from now if the diff is greater than or equal to a year', () => {
       expect(fromNow(new Date('2021-01-01'))).toEqual('1년');
       expect(fromNow(new Date('2019-01-01'))).toEqual('1년');
       expect(fromNow(new Date('2022-01-01'))).toEqual('2년');
@@ -466,37 +466,39 @@ describe('DateUtil', () => {
       expect(fromNow(new Date('2022-12-31'))).toEqual('2년');
       expect(fromNow(new Date('2018-12-31'))).not.toEqual('2년');
     });
-    it('should return month diff from now', () => {
+    it('should return month diff from now if the diff is greater than a month', () => {
       expect(fromNow(new Date('2020-12-01'))).toEqual('11달');
       expect(fromNow(new Date('2020-12-31'))).toEqual('11달');
       expect(fromNow(new Date('2020-02-01'))).toEqual('1달');
       expect(fromNow(new Date('2020-02-28'))).toEqual('1달');
       expect(fromNow(new Date('2019-12-01'))).toEqual('1달');
       expect(fromNow(new Date('2019-12-02'))).not.toEqual('1달');
+
+      // `shouldHumanize` cases
       expect(fromNow(new Date('2019-11-02'))).toEqual('2달');
       expect(fromNow(new Date('2019-11-30'))).toEqual('2달');
       expect(fromNow(new Date('2019-02-01'))).toEqual('11달');
       expect(fromNow(new Date('2019-02-02'))).toEqual('11달');
     });
-    it('should return day diff from now', () => {
+    it('should return day diff from now if the diff is greater than or equal to a day', () => {
       expect(fromNow(new Date('2020-01-02'))).toEqual('1일');
       expect(fromNow(new Date('2020-01-31'))).toEqual('30일');
       expect(fromNow(new Date('2019-12-31'))).toEqual('1일');
       expect(fromNow(new Date('2019-12-02'))).toEqual('30일');
     });
-    it('should return hour diff from now', () => {
+    it('should return hour diff from now if the diff is greater or equal than an hour', () => {
       expect(fromNow(new Date('2020-01-01 01:00:00Z'))).toEqual('1시간');
       expect(fromNow(new Date('2020-01-01 23:00:00Z'))).toEqual('23시간');
       expect(fromNow(new Date('2019-12-31 23:00:00Z'))).toEqual('1시간');
       expect(fromNow(new Date('2019-12-31 01:00:00Z'))).toEqual('23시간');
     });
-    it('should return minute diff from now', () => {
+    it('should return minute diff from now if the diff is greater or equal than a minute', () => {
       expect(fromNow(new Date('2020-01-01 00:59:00Z'))).toEqual('59분');
       expect(fromNow(new Date('2020-01-01 00:01:00Z'))).toEqual('1분');
       expect(fromNow(new Date('2019-12-31 23:01:00Z'))).toEqual('59분');
       expect(fromNow(new Date('2019-12-31 23:59:00Z'))).toEqual('1분');
     });
-    it('should return second diff from now', () => {
+    it('should return second diff from now if the diff is greater or equal than a second', () => {
       expect(fromNow(new Date('2020-01-01 00:00:59Z'))).toEqual('59초');
       expect(fromNow(new Date('2020-01-01 00:00:01Z'))).toEqual('1초');
       expect(fromNow(new Date('2019-12-31 23:59:01Z'))).toEqual('59초');


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
moment.fromNow()를 직접 사용하는 곳을 대체하기 위한 기능 필요

https://github.com/search?q=org%3Aday1co%20OR%20org%3Afastcampus%20OR%20org%3Aday1coloso%20OR%20org%3Aday1snowball%20OR%20org%3Aday1lemonade%20fromNow&type=code

## 무엇을 어떻게 변경했나요?
DateUtil.fromNow() 추가.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
인자로 받은 날짜와 현재가 얼마나 차이 나는지 적당한 년/월/일 시/분/초 차이로 표기해주는 기능입니다.

현재 시간이 2020-01-01 00:00:00 이라 했을때,
2019-02-15 00:00:00 와의 차이는 정확하게는 11개월이 안됩니다만, 기존 moment.fromNow() 는 11달이라 표기하고 있어 이에 맞추기 위해 diff에 ignoreAccuracy 옵션을 추가했습니다.

## 어떻게 테스트 하셨나요?
npm test
