### PR TITLE
feat: setNextPagination 기능 보완

### DIFF
--- a/src/misc-util/misc-util.spec.ts
+++ b/src/misc-util/misc-util.spec.ts
@@ -45,8 +45,13 @@ describe('Miscellaneous Util', () => {
   });
 
   describe('setNextPagination', () => {
-    test('정상실행', () => {
+    test('정상실행(isNext: true)', () => {
       const result = MiscUtil.setNextPagination({ page: 2, limit: 30 });
+      expect(result).toStrictEqual({ limit: 31, offset: 30 });
+    });
+
+    test('정상실행(isNext: false)', () => {
+      const result = MiscUtil.setNextPagination({ page: 2, limit: 30, isNext: false });
       expect(result).toStrictEqual({ limit: 30, offset: 30 });
     });
 
@@ -65,6 +70,12 @@ describe('Miscellaneous Util', () => {
     test('페이지당 갯수가 0보다 같거나 작은 경우 Exception', () => {
       expect(() => {
         MiscUtil.setNextPagination({ page: 1, limit: 0 });
+      }).toThrow(Error);
+    });
+
+    test('limit가 maxLimit를 넘어서는 경우 Exception', () => {
+      expect(() => {
+        MiscUtil.setNextPagination({ page: 1, limit: 1000 });
       }).toThrow(Error);
     });
   });

--- a/src/misc-util/misc-util.ts
+++ b/src/misc-util/misc-util.ts
@@ -29,7 +29,17 @@ export namespace MiscUtil {
     return { firstPage, lastPage, currentPage, pages };
   }
 
-  export function setNextPagination({ page, limit }: { page: number; limit: number }) {
+  export function setNextPagination({
+    page,
+    limit,
+    maxLimit = 100,
+    isNext = true,
+  }: {
+    page: number;
+    limit: number;
+    maxLimit?: number;
+    isNext?: boolean;
+  }) {
     if (!Number.isInteger(page) || !Number.isInteger(limit)) {
       throw new Error(`page or count number is not Integer type (page: ${page}, count: ${limit})`);
     }
@@ -38,8 +48,13 @@ export namespace MiscUtil {
       throw new Error(`page or count number less than or equal to 0 (page: ${page}, count: ${limit})`);
     }
 
-    const offset = (page - 1) * limit;
+    if (maxLimit < limit) {
+      throw new Error(`limit number lager than maxLimit (limit: ${limit}, maxLimit: ${maxLimit})`);
+    }
 
-    return { offset, limit };
+    const offset = (page - 1) * limit;
+    const count = isNext ? ++limit : limit;
+
+    return { offset, limit: count };
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정


## 무엇을 어떻게 변경했나요?
- setNextPagination을 통해 next disabled 체크가 가능하도록 limit를 하나 늘려준다.
- maxLimit를 둬서 필요 이상의 데이터를 요청하지 못하도록 제한한다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
<Previous | Next> 페이징을 사용하기 위한 기능입니다.