### PR TITLE
fix: time-range의 interval 계산시 부동소수점 방어

### DIFF
--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -90,6 +90,7 @@ describe('NumberUtil', () => {
     });
 
     it('should convert from decimal places up', () => {
+      expect(NumberUtil.decimalRoundUp(100, 0)).toEqual(100);
       expect(NumberUtil.decimalRoundUp(100, 3)).toEqual(100000);
       expect(NumberUtil.decimalRoundUp(1.23456, 5)).toEqual(123456);
       expect(NumberUtil.decimalRoundUp(100.2, 5)).toEqual(10020000);
@@ -100,6 +101,7 @@ describe('NumberUtil', () => {
     });
 
     it('should convert from decimal places down', () => {
+      expect(NumberUtil.decimalRoundDown(100000, 0)).toEqual(100000);
       expect(NumberUtil.decimalRoundDown(100000, 3)).toEqual(100);
       expect(NumberUtil.decimalRoundDown(123456, 5)).toEqual(1.23456);
       expect(NumberUtil.decimalRoundDown(10020000, 5)).toEqual(100.2);

--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -124,6 +124,27 @@ describe('TimeRange Util', () => {
         expect(timeRange.totalInterval()).toEqual(totalInterval);
       });
 
+      it('decimal merge to one', async () => {
+        const timeRange = new TimeRange();
+        timeRange.add({
+          start: 1.1,
+          end: 11.1,
+          interval: 9.1,
+        });
+        timeRange.add({
+          start: 1.2,
+          end: 30.2,
+          interval: 10.2,
+        });
+        // native JS 9.1 + 10.2 = 19.299999999999997
+        expect(timeRange.totalInterval()).toEqual(19.3);
+        expect(timeRange.value().length).toEqual(2);
+        timeRange.merge(true);
+        expect(timeRange.value().length).toEqual(1);
+        expect(timeRange.value()[0].interval).toEqual(19.3);
+        expect(timeRange.value()[0].end).toEqual(30.2);
+      });
+
       it('cale decimal points in the totalPlayTime', async () => {
         const timeRange1 = new TimeRange();
         timeRange1.add({

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -24,7 +24,9 @@ export class TimeRange {
           const prevSection: TimeSection = p[p.length - 1];
           if (prevSection.end >= v.start) {
             prevSection.end = v.end > prevSection.end ? v.end : prevSection.end;
-            prevSection.interval += v.interval;
+            prevSection.interval = NumberUtil.decimalRoundDown(
+              NumberUtil.decimalRoundUp(prevSection.interval) + NumberUtil.decimalRoundUp(v.interval)
+            );
           } else {
             p.push(v);
           }
@@ -37,10 +39,12 @@ export class TimeRange {
     return this.section;
   }
   totalInterval() {
-    return this.section.reduce((p, v) => {
-      p = p + v.interval;
+    const result = this.section.reduce((p, v) => {
+      const interval = NumberUtil.decimalRoundUp(v.interval, this.decimalPlaces);
+      p = p + interval;
       return p;
     }, 0);
+    return NumberUtil.decimalRoundDown(result, this.decimalPlaces);
   }
   totalPlayTime() {
     const result = this.section.reduce((p, v) => {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

[feature/time-ragne-decimal](https://github.com/day1co/pebbles/pull/197) 에서 이어지는 PR입니다.

merge(), totalinterval() 작업시에도 부동소수점을 방어하는 계산을 적용합니다.

두 함수 모두 서비스에서 사용하고있는걸 고려하여 적용했지만 검토가 필요합니다.

## 어떻게 테스트 하셨나요?

jest 테스트 추가
