### PR TITLE
time-range: 반올림처리 개선

### DIFF
--- a/src/number-util/number-util.ts
+++ b/src/number-util/number-util.ts
@@ -42,6 +42,9 @@ export namespace NumberUtil {
     if (isNaN(floatValue)) {
       throw new Error(`unable to convert "${floatValue}" to number type`);
     }
+    if (decimal === 0) {
+      return Math.round(floatValue);
+    }
     const factor = Math.pow(10, decimal);
     return Math.round(floatValue * factor);
   };
@@ -49,6 +52,9 @@ export namespace NumberUtil {
   export const decimalRoundDown = (value: number, decimal = 2) => {
     if (isNaN(value)) {
       throw new Error(`unable to convert "${value}" to number type`);
+    }
+    if (decimal === 0) {
+      return value;
     }
     return value / Math.pow(10, decimal);
   };

--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -240,20 +240,6 @@ describe('TimeRange Util', () => {
         });
         expect(timeRange8.totalPlayTime()).toEqual(62);
       });
-
-      it('increased correction totalPlayTime', async () => {
-        const timeRange1 = new TimeRange();
-        expect(timeRange1.increaseCorrection(100)).toEqual(100);
-
-        const timeRange2 = new TimeRange(); // 0.01%
-        expect(timeRange2.increaseCorrection(10000)).toEqual(10001);
-
-        const timeRange3 = new TimeRange([], 0, 0.001); // 0.1%
-        expect(timeRange3.increaseCorrection(20000)).toEqual(20020);
-
-        const timeRange4 = new TimeRange([], 0, 0.01); // 1%
-        expect(timeRange4.increaseCorrection(30000)).toEqual(30300);
-      });
     });
   });
 });

--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -125,7 +125,7 @@ describe('TimeRange Util', () => {
       });
 
       it('decimal merge to one', async () => {
-        const timeRange = new TimeRange();
+        const timeRange = new TimeRange([], 1);
         timeRange.add({
           start: 1.1,
           end: 11.1,
@@ -146,7 +146,7 @@ describe('TimeRange Util', () => {
       });
 
       it('cale decimal points in the totalPlayTime', async () => {
-        const timeRange1 = new TimeRange();
+        const timeRange1 = new TimeRange([], 1);
         timeRange1.add({
           start: 99.9,
           end: 100.1,
@@ -155,7 +155,7 @@ describe('TimeRange Util', () => {
         // native JS 100.1 - 99.9 = 0.19999999999998863
         expect(timeRange1.totalPlayTime()).toEqual(0.2);
 
-        const timeRange2 = new TimeRange();
+        const timeRange2 = new TimeRange([], 5);
         timeRange2.add({
           start: 0,
           end: 59.08332,
@@ -212,6 +212,47 @@ describe('TimeRange Util', () => {
         });
         timeRange5.merge();
         expect(timeRange5.totalPlayTime()).toEqual(3600000000.99);
+
+        const timeRange6 = new TimeRange();
+        timeRange6.add({
+          start: 0,
+          end: 100,
+          interval: 100,
+        });
+        timeRange6.add({
+          start: 90,
+          end: 60 * 60 * 1000000 + 0.99, // 1,000,000 hours
+          interval: 60 * 60 * 1000000 + 0.99,
+        });
+        timeRange6.merge();
+        expect(timeRange6.totalPlayTime()).toEqual(3600000001);
+
+        const timeRange8 = new TimeRange();
+        timeRange8.add({
+          start: 0,
+          end: 59.08332,
+          interval: 59.08332,
+        });
+        timeRange8.add({
+          start: 227.26884,
+          end: 230.481,
+          interval: 6.7765600000000035,
+        });
+        expect(timeRange8.totalPlayTime()).toEqual(62);
+      });
+
+      it('increased correction totalPlayTime', async () => {
+        const timeRange1 = new TimeRange();
+        expect(timeRange1.increaseCorrection(100)).toEqual(100);
+
+        const timeRange2 = new TimeRange(); // 0.01%
+        expect(timeRange2.increaseCorrection(10000)).toEqual(10001);
+
+        const timeRange3 = new TimeRange([], 0, 0.001); // 0.1%
+        expect(timeRange3.increaseCorrection(20000)).toEqual(20020);
+
+        const timeRange4 = new TimeRange([], 0, 0.01); // 1%
+        expect(timeRange4.increaseCorrection(30000)).toEqual(30300);
       });
     });
   });

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -1,12 +1,19 @@
 import { NumberUtil } from '../number-util';
 import { TimeSection } from './time-range.interface';
 
+/**
+ * @params loadSection: TimeSection 배열
+ * @params decimalPlaces: TimeSection 계산시 소수점 자리수를 설정하여 반올림 처리 (default 0)
+ * @params correction: 모든 클립 playtime의 오차 보정 수치 (default 0.01%)
+ */
 export class TimeRange {
   private section!: Array<TimeSection>;
-  readonly decimalPlaces: number;
-  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 5) {
+  decimalPlaces: number;
+  correction: number;
+  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 0, correction = 0.0001) {
     this.section = loadSection;
     this.decimalPlaces = decimalPlaces;
+    this.correction = correction;
   }
   add(piece: TimeSection) {
     this.section.push(piece);
@@ -53,5 +60,8 @@ export class TimeRange {
       return p + (end - start);
     }, 0);
     return NumberUtil.decimalRoundDown(result, this.decimalPlaces);
+  }
+  increaseCorrection(allPlayTime: number) {
+    return allPlayTime + Math.round(allPlayTime * this.correction);
   }
 }

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -4,16 +4,13 @@ import { TimeSection } from './time-range.interface';
 /**
  * @params loadSection: TimeSection 배열
  * @params decimalPlaces: TimeSection 계산시 소수점 자리수를 설정하여 반올림 처리 (default 0)
- * @params correction: 모든 클립 playtime의 오차 보정 수치 (default 0.01%)
  */
 export class TimeRange {
   private section!: Array<TimeSection>;
   decimalPlaces: number;
-  correction: number;
-  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 0, correction = 0.0001) {
+  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 0) {
     this.section = loadSection;
     this.decimalPlaces = decimalPlaces;
-    this.correction = correction;
   }
   add(piece: TimeSection) {
     this.section.push(piece);
@@ -60,8 +57,5 @@ export class TimeRange {
       return p + (end - start);
     }, 0);
     return NumberUtil.decimalRoundDown(result, this.decimalPlaces);
-  }
-  increaseCorrection(allPlayTime: number) {
-    return allPlayTime + Math.round(allPlayTime * this.correction);
   }
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

~skillflo에서 time-range 운영시 100% 시청했음에도,~
~100%로 계산되지 않는 문제가 생겨 오차범위를 보정하는 계산을 추가합니다.~

~TimeRange 클래스는 단일 클립의 재생시간을 다루지만~
~보정값을 더한 시간 계산에는 비즈니스가 공통으로 사용될것으로 보여 기존 클래스에 추가하였습니다.~


## 무엇을 어떻게 변경했나요?

- 소수점자리수 미사용시(0) 계산 로직을 넘어감
- 기본 소수점처리는 반올림 처리 되도록 개선
- ~increaseCorrection(:number) 추가~

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

수강률 정책 정리 https://fastcampus.atlassian.net/wiki/spaces/BPOLMS/pages/2615181602/-+23.12.18



## 어떻게 테스트 하셨나요?

테스트 추가
