### PR TITLE
feat: CryptoUtil.createAesKey 추가 

### DIFF
--- a/src/crypto-util/crypto-util.spec.ts
+++ b/src/crypto-util/crypto-util.spec.ts
@@ -22,6 +22,14 @@ describe('CryptoUtil', () => {
     });
   });
 
+  describe('createAesKey', () => {
+    it('should return a Uint8Array', async () => {
+      const result = await CryptoUtil.createAesKey(256);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+  });
+
   describe('encodeBase64', () => {
     it('should accept string and return a base64 encoded string', () => {
       const result = CryptoUtil.encodeBase64('hello world');

--- a/src/crypto-util/crypto-util.ts
+++ b/src/crypto-util/crypto-util.ts
@@ -1,6 +1,13 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const crypto: any = globalThis.crypto;
+import type { webcrypto } from 'crypto';
+
+declare global {
+  namespace globalThis {
+    // eslint-disable-next-line no-var
+    var crypto: typeof webcrypto;
+  }
+}
+
+const crypto = globalThis.crypto;
 
 export namespace CryptoUtil {
   export const sha256 = async (data: string | Uint8Array): Promise<Uint8Array> => {
@@ -12,6 +19,18 @@ export namespace CryptoUtil {
 
   export const createRandomBytes = (bytes: number): Uint8Array => {
     return crypto.getRandomValues(new Uint8Array(bytes));
+  };
+
+  export const createAesKey = async (length: 128 | 192 | 256): Promise<Uint8Array> => {
+    const key = await crypto.subtle.generateKey(
+      {
+        name: 'AES-GCM',
+        length: length,
+      },
+      true,
+      ['encrypt', 'decrypt']
+    );
+    return new Uint8Array(await crypto.subtle.exportKey('raw', key));
   };
 
   export const encodeBase64 = (data: Uint8Array | string): string => {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

AESKey 를 안전하게 만들기 위해 createAesKey 메서드를 추가 합니다. 

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

MDN 에 따르면 암호화 키를 만들때는 getRandomValues() 대신 generateKey() 를 사용하라고 합니다. 
https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
```
Don't use getRandomValues() to generate encryption keys. Instead, use the [generateKey()](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey) method. There are a few reasons for this; for example, getRandomValues() is not guaranteed to be running in a secure context.
```

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
