### PR TITLE
time-range: merge 함수에서 interval계산에 소수점을 반영

### DIFF
--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -143,6 +143,22 @@ describe('TimeRange Util', () => {
         expect(timeRange.value().length).toEqual(1);
         expect(timeRange.value()[0].interval).toEqual(19.3);
         expect(timeRange.value()[0].end).toEqual(30.2);
+
+        const timeRange2 = new TimeRange([], 5);
+        timeRange2.add({
+          start: 1.11111,
+          end: 11.11111,
+          interval: 9.111111,
+        });
+        timeRange2.add({
+          start: 1.22222,
+          end: 30.22222,
+          interval: 10.22222,
+        });
+        timeRange2.merge(true);
+        expect(timeRange2.value().length).toEqual(1);
+        expect(timeRange2.value()[0].interval).toEqual(19.33333);
+        expect(timeRange2.value()[0].end).toEqual(30.22222);
       });
 
       it('cale decimal points in the totalPlayTime', async () => {

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -30,7 +30,9 @@ export class TimeRange {
           if (prevSection.end >= v.start) {
             prevSection.end = v.end > prevSection.end ? v.end : prevSection.end;
             prevSection.interval = NumberUtil.decimalRoundDown(
-              NumberUtil.decimalRoundUp(prevSection.interval) + NumberUtil.decimalRoundUp(v.interval)
+              NumberUtil.decimalRoundUp(prevSection.interval, this.decimalPlaces) +
+                NumberUtil.decimalRoundUp(v.interval, this.decimalPlaces),
+              this.decimalPlaces
             );
           } else {
             p.push(v);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

merge 할때 interval 계산시 소수점을 반영.

```
// 카테노이드의 데이터를 최대한 원본을 유지할때

const timeRange2 = new TimeRange([], 5);
```

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

테스트코드 추가

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
