### PR TITLE
refactor: 미시청 마지막 구간에서 decimal 옵션으로 처리하도록 수정

### DIFF
--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -260,7 +260,7 @@ describe('TimeRange Util', () => {
 
     describe('no time section', () => {
       it('should be return unwatched time range', async () => {
-        const timeRange = new TimeRange();
+        const timeRange = new TimeRange([], 5);
         timeRange.add({ end: 6.74336, start: 0, interval: 6.74336 });
         timeRange.add({ end: 67.15486, start: 17, interval: 50.15486 });
         timeRange.add({ end: 78.2383, start: 78, interval: 0.2383 });
@@ -286,6 +286,11 @@ describe('TimeRange Util', () => {
         const timeRange = new TimeRange();
         const result = timeRange.getUnwatchedTimeRange(500);
         expect(result).toEqual([{ start: 0, end: 500 }]);
+      });
+      it('should be return empty section, if full watched - decimalPlaces', async () => {
+        const timeRange = new TimeRange([{ end: 9.74336, start: 0, interval: 9.74336 }], 0);
+        const result = timeRange.getUnwatchedTimeRange(10);
+        expect(result).toEqual([]);
       });
     });
   });

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -103,7 +103,9 @@ export class TimeRange {
     }
 
     // 마지막 시청 구간의 끝부터 클립의 끝까지의 미시청 구간 추가
-    if (timeRange[timeRange.length - 1].end < endTime) {
+    const start = NumberUtil.decimalRoundUp(timeRange[timeRange.length - 1].end, this.decimalPlaces);
+    const end = NumberUtil.decimalRoundUp(endTime, this.decimalPlaces);
+    if (start < end) {
       unwatchedTimeRange.push({
         start: timeRange[timeRange.length - 1].end,
         end: endTime,


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [ ] 새로운 기능
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
![image](https://github.com/day1co/pebbles/assets/43664181/5779d409-4246-4ece-960e-2675f23f9dff)


콜러스는 클립에 지정된 마감시간보다 더 적게 측정되는 경우가 있다.
이런 경우 강의클립을 다 시청하였더라도 미시청구간이 발생된다.

## 무엇을 어떻게 변경했나요?
마지막 구간의 경우 반올림 처리하여 미시청구간을 없애도록 한다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
test code

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
