### PR TITLE
fix: change timezone pst value to pst8pdt

### DIFF
--- a/src/date-util/date-util.const.ts
+++ b/src/date-util/date-util.const.ts
@@ -15,6 +15,6 @@ export const ONE_HOUR_IN_MILLI = ONE_HOUR_IN_SECOND * ONE_SECOND_IN_MILLI;
 export const ONE_DAY_IN_MILLI = ONE_DAY_IN_SECOND * ONE_SECOND_IN_MILLI;
 
 export const TIMEZONE_SEOUL = 'Asia/Seoul';
-export const TIMEZONE_PST = 'PST';
+export const TIMEZONE_PST = 'PST8PDT';
 export const TIMEZONE_TOKYO = 'Asia/Tokyo';
 export const TIMEZONE_UTC = 'UTC';

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -350,7 +350,7 @@ describe('DateUtil', () => {
       expect(
         format(testDatetime, { format: 'YYYY-MM-DDTHH:mm:ss.SSSZZ', isUtc: false, timeZone: 'Asia/Seoul' })
       ).toEqual(`2022-02-23T10:23:45.678+0900`);
-      expect(format(testDatetime, { isUtc: false, timeZone: 'PST' })).toBe('2022-02-22 17:23:45');
+      expect(format(testDatetime, { isUtc: false, timeZone: 'PST8PDT' })).toBe('2022-02-22 17:23:45');
     });
   });
 
@@ -367,7 +367,7 @@ describe('DateUtil', () => {
       expect(formatInIso8601(testDatetime, { format: DATETIME_FORMAT, isUtc: false, timeZone: 'Asia/Seoul' })).toEqual(
         `2022-02-23T10:23:45+09:00`
       );
-      expect(formatInIso8601(testDatetime, { isUtc: false, timeZone: 'PST' })).toEqual('2022-02-22T17:23:45-08:00');
+      expect(formatInIso8601(testDatetime, { isUtc: false, timeZone: 'PST8PDT' })).toEqual('2022-02-22T17:23:45-08:00');
     });
   });
 

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -16,7 +16,7 @@ import {
 import type { LocalDateTimeFormatOpts, TimeAnnotationSet } from './date-util.interface';
 import type { CalcDatetimeOpts, DatetimeFormatOpts, IsoDatetimeFormatOpts } from './date-util.type';
 
-const timeZoneMap: Record<TimeZoneType, number> = { 'Asia/Seoul': 540, 'Asia/Tokyo': 540, PST: -480, UTC: 0 };
+const timeZoneMap: Record<TimeZoneType, number> = { 'Asia/Seoul': 540, 'Asia/Tokyo': 540, PST8PDT: -480, UTC: 0 };
 const logger = LoggerFactory.getLogger('pebbles:date-util');
 
 export namespace DateUtil {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://fastcampus.atlassian.net/browse/COL-5261
## 무엇을 어떻게 변경했나요?
- [IANA DataBase](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) 공식 지원 속성인 PST8PDT로 변경.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
PST는 태평양 표준시(Pacific Standard Time)를 의미합니다. 그러나 “PST”는 Intl.DateTimeFormat에서 사용할 수 있는 유효한 IANA 시간대 식별자가 아닙니다.

## 디펜던시 변경이 있나요?
x
## 어떻게 테스트 하셨나요?
스모크
## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
