### PR TITLE
Feat: timeRange에 앞뒤로 buffer sec 추가

### DIFF
--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -332,11 +332,13 @@ describe('TimeRange Util', () => {
         };
         timeRange.add(ts);
 
-        expect(timeRange.value().length).toEqual(4);
+        expect(timeRange.value().length).toEqual(2);
 
         timeRange.merge(true);
 
         expect(timeRange.value().length).toEqual(1);
+        expect(timeRange.value()[0].start).toEqual(0);
+        expect(timeRange.value()[0].end).toEqual(bufferSec + 40);
       });
     });
   });

--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -293,5 +293,51 @@ describe('TimeRange Util', () => {
         expect(result).toEqual([]);
       });
     });
+
+    describe('check buffer Constructor', () => {
+      it('start interval 1, start+10 = end, buffer sec 60, merge to one', async () => {
+        const loadSection: Array<TimeSection> = [];
+        const bufferSec: number = 60;
+        for (let i = 0; i < 10; i++) {
+          const o: TimeSection = {
+            start: i,
+            end: i + 10,
+            interval: 10,
+          };
+          loadSection.push(o);
+        }
+        const timeRange = new TimeRange(loadSection, 0, bufferSec);
+        expect(timeRange.value().length).toEqual(10);
+
+        timeRange.merge(true);
+
+        expect(timeRange.value().length).toEqual(1);
+        expect(timeRange.value()[0].start).toEqual(0);
+        expect(timeRange.value()[0].end).toEqual(bufferSec + 19);
+      });
+      it('split start and end, merge to one', async () => {
+        const bufferSec: number = 20;
+        const timeRange = new TimeRange([], 0, bufferSec);
+        let ts: TimeSection = {
+          start: 10,
+          end: 20,
+          interval: 10,
+        };
+        timeRange.add(ts);
+
+        ts = {
+          start: 30,
+          end: 40,
+          interval: 10,
+        };
+        timeRange.add(ts);
+
+        expect(timeRange.value().length).toEqual(4);
+
+        timeRange.merge(true);
+
+        expect(timeRange.value().length).toEqual(1);
+      });
+    });
   });
 });

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -8,14 +8,34 @@ import { TimeSection } from './time-range.interface';
 export class TimeRange {
   private section!: Array<TimeSection>;
   decimalPlaces: number;
+  bufferSec: number;
 
-  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 0) {
+  constructor(loadSection: Array<TimeSection> = [], decimalPlaces = 0, bufferSec = 0) {
     this.section = loadSection;
     this.decimalPlaces = decimalPlaces;
+    this.bufferSec = bufferSec;
+
+    if (this.bufferSec > 0) {
+      for (let i = 0; i < this.section.length; i++) {
+        const bufferStart = Math.min(this.section[i].start - this.bufferSec, 0);
+        this.section[i].start = Math.max(0, this.section[i].start - this.bufferSec);
+        this.section[i].end = this.section[i].end + this.bufferSec;
+        this.section[i].interval = bufferStart + this.section[i].interval + this.bufferSec * 2;
+      }
+    }
   }
 
   add(piece: TimeSection) {
     this.section.push(piece);
+
+    if (this.bufferSec > 0) {
+      const bufferStart = Math.min(piece.start - this.bufferSec, 0);
+      this.section.push({
+        start: Math.max(0, piece.start - this.bufferSec),
+        end: piece.end + this.bufferSec,
+        interval: bufferStart + piece.interval + this.bufferSec * 2,
+      });
+    }
   }
 
   merge(debug = false) {

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -26,8 +26,6 @@ export class TimeRange {
   }
 
   add(piece: TimeSection) {
-    this.section.push(piece);
-
     if (this.bufferSec > 0) {
       const bufferStart = Math.min(piece.start - this.bufferSec, 0);
       this.section.push({
@@ -35,6 +33,8 @@ export class TimeRange {
         end: piece.end + this.bufferSec,
         interval: bufferStart + piece.interval + this.bufferSec * 2,
       });
+    } else {
+      this.section.push(piece);
     }
   }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
timeRange가 이동 없이 시청하여도 네트워크 및 환경 이슈로 시청구간이 끊기는 경우가 발생됩니다.
https://fastcampus.atlassian.net/browse/FCLXP-6928

## 무엇을 어떻게 변경했나요?
구간시간의 앞뒤로 buffer 시간을 설정하여 관련 이슈를 해소하고자 합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
로컬 및 staging 테스트 

<img width="470" alt="image" src="https://github.com/user-attachments/assets/a0c31513-f96c-4a6e-ac50-9a9c3c6a19ca">


## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
