### PR TITLE
add mask type default for masking all text

### DIFF
--- a/src/string-util/string-util.spec.ts
+++ b/src/string-util/string-util.spec.ts
@@ -9,6 +9,7 @@ describe('StringUtil', () => {
       expect(StringUtil.maskPrivacy('', 'email')).toBe('');
       expect(StringUtil.maskPrivacy('', 'name')).toBe('');
       expect(StringUtil.maskPrivacy('', 'phone')).toBe('');
+      expect(StringUtil.maskPrivacy('', 'default')).toBe('');
     });
 
     it('should mask names except the first and last characters', () => {
@@ -170,6 +171,18 @@ describe('StringUtil', () => {
       expect(StringUtil.maskPrivacy(testOffshoring3, 'offshoring')).toBe('***-******-****');
       expect(StringUtil.maskPrivacy(testOffshoring4, 'offshoring')).toBe('**********');
       expect(StringUtil.maskPrivacy(testOffshoring5, 'offshoring')).toBe('***');
+    });
+
+    it('should mask the entire string when the type is default', () => {
+      const testDefault1 = '123456';
+      const testDefault2 = '010101';
+      const testDefault3 = '19800101';
+      const testDefault4 = '성별';
+
+      expect(StringUtil.maskPrivacy(testDefault1, 'default')).toBe('******');
+      expect(StringUtil.maskPrivacy(testDefault2, 'default')).toBe('******');
+      expect(StringUtil.maskPrivacy(testDefault3, 'default')).toBe('********');
+      expect(StringUtil.maskPrivacy(testDefault4, 'default')).toBe('**');
     });
   });
 

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -34,6 +34,7 @@ export namespace StringUtil {
       bankAccount: { start: 3, end: text.length - 3 },
       address: { start: getMaskingStartIndexOfAddress(text), end: text.length },
       resident: { start: text.charAt(6) === '-' ? 7 : 6, end: text.length },
+      default: { start: 0, end: text.length },
     };
 
     const start = maskingRule[type].start;

--- a/src/string-util/string-util.type.ts
+++ b/src/string-util/string-util.type.ts
@@ -1,1 +1,9 @@
-export type PrivacyType = 'name' | 'phone' | 'email' | 'bankAccount' | 'address' | 'resident' | 'offshoring';
+export type PrivacyType =
+  | 'name'
+  | 'phone'
+  | 'email'
+  | 'bankAccount'
+  | 'address'
+  | 'resident'
+  | 'offshoring'
+  | 'default';


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

고객 생일 성별 컬럼 마스킹을 위한 타입추가

두 컬럼명과 같게 가려고 했으나 이와같이 모든 문자를 마스킹하는 케이스가 더 나올수가 있을거같아서 default로 추가하였습니다. 의견들어보고 따로 추가할지 그대로 가야할지 정하겠습니다.

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
