### PR TITLE
feat/modify member_clip_progress interval logic

### DIFF
--- a/src/time-range/time-range.spec.ts
+++ b/src/time-range/time-range.spec.ts
@@ -129,19 +129,18 @@ describe('TimeRange Util', () => {
         timeRange.add({
           start: 1.1,
           end: 11.1,
-          interval: 9.1,
+          interval: 10,
         });
         timeRange.add({
           start: 1.2,
           end: 30.2,
-          interval: 10.2,
+          interval: 29,
         });
-        // native JS 9.1 + 10.2 = 19.299999999999997
-        expect(timeRange.totalInterval()).toEqual(19.3);
+        expect(timeRange.totalInterval()).toEqual(39);
         expect(timeRange.value().length).toEqual(2);
         timeRange.merge(true);
         expect(timeRange.value().length).toEqual(1);
-        expect(timeRange.value()[0].interval).toEqual(19.3);
+        expect(timeRange.value()[0].interval).toEqual(39);
         expect(timeRange.value()[0].end).toEqual(30.2);
 
         const timeRange2 = new TimeRange([], 5);
@@ -256,6 +255,16 @@ describe('TimeRange Util', () => {
         });
         expect(timeRange8.totalPlayTime()).toEqual(62);
       });
+
+      it('add the larger value of interval and diff from start and end to totalInterval ', async () => {
+        const timeRange = new TimeRange([], 0);
+        timeRange.add({ end: 28.37231, start: 0, interval: 28.37231 });
+        timeRange.add({ end: 13.87707, start: 0, interval: 13.87707 });
+        timeRange.add({ end: 99.76297, start: 85.45316, interval: 14.30981 });
+        timeRange.add({ end: 360.66692, start: 314.84983, interval: 45.81709 });
+
+        expect(timeRange.totalInterval()).toBeGreaterThanOrEqual(timeRange.totalPlayTime());
+      });
     });
 
     describe('no time section', () => {
@@ -297,7 +306,7 @@ describe('TimeRange Util', () => {
     describe('check buffer Constructor', () => {
       it('start interval 1, start+10 = end, buffer sec 60, merge to one', async () => {
         const loadSection: Array<TimeSection> = [];
-        const bufferSec: number = 60;
+        const bufferSec = 60;
         for (let i = 0; i < 10; i++) {
           const o: TimeSection = {
             start: i,
@@ -316,7 +325,7 @@ describe('TimeRange Util', () => {
         expect(timeRange.value()[0].end).toEqual(bufferSec + 19);
       });
       it('split start and end, merge to one', async () => {
-        const bufferSec: number = 20;
+        const bufferSec = 20;
         const timeRange = new TimeRange([], 0, bufferSec);
         let ts: TimeSection = {
           start: 20,

--- a/src/time-range/time-range.ts
+++ b/src/time-range/time-range.ts
@@ -78,7 +78,13 @@ export class TimeRange {
   totalInterval() {
     const result = this.section.reduce((p, v) => {
       const interval = NumberUtil.decimalRoundUp(v.interval, this.decimalPlaces);
-      p = p + interval;
+
+      //XXX: 반올림 때문에 interval이 end-start보다 작은 경우가 있음
+      const end = NumberUtil.decimalRoundUp(v.end, this.decimalPlaces);
+      const start = NumberUtil.decimalRoundUp(v.start, this.decimalPlaces);
+      const roundSumInterval = end - start;
+
+      p = p + (interval > roundSumInterval ? interval : roundSumInterval);
       return p;
     }, 0);
     return NumberUtil.decimalRoundDown(result, this.decimalPlaces);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?
- [X] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
로직 변경 및 사유
로직 변경 사유
- interval은 반올림을 한번만 실행되고, total은 반올림이 두번 실행된다.
- total은 interval보다 클 수 없지만, 반올림으로 인해, total이 큰 경우가 생긴다.

## 무엇을 어떻게 변경했나요?
로직 변경
- interval을 계산 시, 반올림이 된 start, end의 값을 비교하여 더 큰 수를 interval에 더한다

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
totalPlayTime은 start, end의 반올림을 실행하고
totalInterval은 interval의 반올림만 실행한다.

예시)
```
const first = [{"end": 28.37231, "start": 0, "interval": 28.37231}];
const second = [
  {"end": 13.87707, "start": 0, "interval": 13.87707},
  {"end": 99.76297, "start": 85.45316, "interval": 14.30981},
  {"end": 360.66692, "start": 314.84983, "interval": 45.81709}
];
const third = [{"end": 95.42274, "start": 0, "interval": 95.42274}];
```
의 데이터에서

interval만 반올림하여 더하면
28 + 14+ 14+ 46 + 95로 197이 나오지만
start, end를 반올림하여 end-start를 계속 더하면
(28 - 0) + (14 - 0) + (100 - 85) + (361 - 315) + (95 - 0)으로 198이 나오게 된다.

interval이 total보다 작으면 안되기 때문에,
interval을 계산할 때, total이 더 크게 되면 interval에 interval대신 total을 더하게 변경

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
로컬 테스트

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="541" alt="image" src="https://github.com/user-attachments/assets/52c0f997-c305-4839-b090-9c070eb93d99" />
