### PR TITLE
4.x deprecations (and more)

### DIFF
--- a/src/boolean-util/boolean-util.spec.ts
+++ b/src/boolean-util/boolean-util.spec.ts
@@ -1,24 +1,24 @@
-import { valueOfBoolean } from './boolean-util';
+import { parseBoolean } from './boolean-util';
 
-describe('valueOfBoolean', () => {
+describe('parseBoolean', () => {
   it('should throw with incompatible input', () => {
-    expect(() => valueOfBoolean('abc')).toThrow();
-    expect(() => valueOfBoolean('1111')).toThrow();
-    expect(() => valueOfBoolean('')).toThrow();
-    expect(() => valueOfBoolean('nay')).toThrow();
+    expect(() => parseBoolean('abc')).toThrow();
+    expect(() => parseBoolean('1111')).toThrow();
+    expect(() => parseBoolean('')).toThrow();
+    expect(() => parseBoolean('nay')).toThrow();
   });
   it('should return parameter in boolean type', () => {
-    expect(valueOfBoolean('true')).toEqual(true);
-    expect(valueOfBoolean('false')).toEqual(false);
-    expect(valueOfBoolean('1')).toEqual(true);
-    expect(valueOfBoolean('0')).toEqual(false);
-    expect(valueOfBoolean('yes')).toEqual(true);
-    expect(valueOfBoolean('no')).toEqual(false);
-    expect(valueOfBoolean('Y')).toEqual(true);
-    expect(valueOfBoolean('N')).toEqual(false);
-    expect(valueOfBoolean('On')).toEqual(true);
-    expect(valueOfBoolean('Off')).toEqual(false);
-    expect(valueOfBoolean('TRUE')).toEqual(true);
-    expect(valueOfBoolean('FALSE')).toEqual(false);
+    expect(parseBoolean('true')).toEqual(true);
+    expect(parseBoolean('false')).toEqual(false);
+    expect(parseBoolean('1')).toEqual(true);
+    expect(parseBoolean('0')).toEqual(false);
+    expect(parseBoolean('yes')).toEqual(true);
+    expect(parseBoolean('no')).toEqual(false);
+    expect(parseBoolean('Y')).toEqual(true);
+    expect(parseBoolean('N')).toEqual(false);
+    expect(parseBoolean('On')).toEqual(true);
+    expect(parseBoolean('Off')).toEqual(false);
+    expect(parseBoolean('TRUE')).toEqual(true);
+    expect(parseBoolean('FALSE')).toEqual(false);
   });
 });

--- a/src/boolean-util/boolean-util.ts
+++ b/src/boolean-util/boolean-util.ts
@@ -1,5 +1,4 @@
-/** @deprecated will be removed soon */
-export function parseBooleanString(boolStr: string): boolean {
+export function valueOfBoolean(boolStr: string): boolean {
   const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
   const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
 

--- a/src/boolean-util/boolean-util.ts
+++ b/src/boolean-util/boolean-util.ts
@@ -1,4 +1,4 @@
-export function valueOfBoolean(boolStr: string): boolean {
+export function parseBoolean(boolStr: string): boolean {
   const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
   const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
 

--- a/src/boolean-util/boolean-util.ts
+++ b/src/boolean-util/boolean-util.ts
@@ -1,4 +1,5 @@
-export function valueOfBoolean(boolStr: string): boolean {
+/** @deprecated will be removed soon */
+export function parseBooleanString(boolStr: string): boolean {
   const TRUE_REGEXP = /^(t(rue)?|y(es)?|on|1)$/i;
   const FALSE_REGEXP = /^(f(alse)?|n(o)?|off|0)$/i;
 

--- a/src/boolean-util/index.ts
+++ b/src/boolean-util/index.ts
@@ -1,1 +1,1 @@
-export { valueOfBoolean } from './boolean-util';
+export { parseBoolean } from './boolean-util';

--- a/src/date-util/date-util.spec.ts
+++ b/src/date-util/date-util.spec.ts
@@ -4,11 +4,7 @@ import {
   durationTo,
   endOfByTimezone,
   formatDate,
-  formatInIso8601,
   fromNow,
-  getDateString,
-  getDatetimeString,
-  getTimestampString,
   getTimezoneOffsetInHours,
   isAdult,
   isLastDateOfMonth,
@@ -23,7 +19,6 @@ import {
 } from './date-util';
 import {
   DATE_FORMAT,
-  DATETIME_FORMAT,
   DATETIME_FORMAT_WITH_MILLIS,
   TIMESTAMP_FORMAT,
   TIMEZONE_PST,
@@ -484,49 +479,6 @@ describe('format', () => {
       formatDate(testDatetime, { format: 'YYYY-MM-DDTHH:mm:ss.SSSZZ', isUtc: false, timeZone: 'Asia/Seoul' })
     ).toEqual(`2022-02-23T10:23:45.678+0900`);
     expect(formatDate(testDatetime, { isUtc: false, timeZone: 'PST8PDT' })).toBe('2022-02-22 17:23:45');
-  });
-});
-
-describe('formatInIso8601', () => {
-  it('should return formatted date string in ISO format string', () => {
-    const testDatetime = new Date(testDatetimeStr8);
-    expect(formatInIso8601(testDatetime, { format: DATE_FORMAT })).toEqual(testDateStr);
-    expect(formatInIso8601(testDatetime, { format: DATETIME_FORMAT })).toEqual(testDatetimeStr5);
-    expect(formatInIso8601(testDatetime, { format: DATETIME_FORMAT_WITH_MILLIS })).toEqual(testDatetimeStr8);
-  });
-  it('should return formatted date string of local time', () => {
-    const testDatetime = new Date(testDatetimeStr8);
-    expect(formatInIso8601(testDatetime, { format: DATETIME_FORMAT, isUtc: false, timeZone: 'Asia/Seoul' })).toEqual(
-      `2022-02-23T10:23:45+09:00`
-    );
-    expect(formatInIso8601(testDatetime, { isUtc: false, timeZone: 'PST8PDT' })).toEqual('2022-02-22T17:23:45-08:00');
-  });
-});
-
-describe('getDateString', () => {
-  it('should return formatted date string', () => {
-    expect(getDateString(new Date(testDatetimeStr8))).toBe(testDateStr);
-  });
-  it('should return formatted date string of local time', () => {
-    expect(getDateString(new Date(testDatetimeStr6), false)).toBe(testDateStr);
-  });
-});
-
-describe('getDatetimeString', () => {
-  it('should return format datetime string', () => {
-    expect(getDatetimeString(new Date(testDatetimeStr8))).toBe(testDatetimeStr5);
-  });
-  it('should return formatted datetime string of local time', () => {
-    expect(getDatetimeString(new Date(testDatetimeStr8), false)).toBe('2022-02-23 10:23:45');
-  });
-});
-
-describe('getTimestampString', () => {
-  it('should return formatted timestamp string', () => {
-    expect(getTimestampString(new Date(testDatetimeStr8))).toBe(testTimestampStr);
-  });
-  it('should return formatted timestamp string of local time', () => {
-    expect(getTimestampString(new Date(testDatetimeStr8), false)).toBe('20220223102345678');
   });
 });
 

--- a/src/date-util/date-util.ts
+++ b/src/date-util/date-util.ts
@@ -2,7 +2,6 @@ import { LoggerFactory } from '../logger';
 import { DatePropertyType, DateType, TimeZoneType } from './date-util-base.type';
 import {
   ADULT_AGE_DEFAULT,
-  DATE_FORMAT,
   DATETIME_FORMAT,
   LOCAL_DATETIME_FORMAT,
   ONE_DAY_IN_MILLI,
@@ -15,7 +14,7 @@ import {
   TIMESTAMP_FORMAT,
 } from './date-util.const';
 import type { TimeAnnotationSet } from './date-util.interface';
-import type { CalcDatetimeOpts, DatetimeFormatOpts, IsoDatetimeFormatOpts } from './date-util.type';
+import type { CalcDatetimeOpts, DatetimeFormatOpts } from './date-util.type';
 
 const timeZoneMap: Record<TimeZoneType, number> = { 'Asia/Seoul': 540, 'Asia/Tokyo': 540, PST8PDT: -480, UTC: 0 };
 const logger = LoggerFactory.getLogger('pebbles:date-util');
@@ -371,61 +370,6 @@ export function formatDate(d: Date, opts?: Readonly<DatetimeFormatOpts>): string
         return match;
     }
   });
-}
-
-/**
- *
- * @description It converts `date` in `opts.format` if it's given. Otherwise the default format would be `YYYY-MM-DDTHH:mm:ssZ`.
- * - Other format options can be `YYYY-MM-DD` or `YYYY-MM-DDTHH:mm:ss.SSSZ`.
- */
-export function formatInIso8601(date: Date, opts?: Readonly<IsoDatetimeFormatOpts>): string {
-  const formatOpts: IsoDatetimeFormatOpts = opts ?? {};
-  formatOpts.format = opts?.format ?? DATETIME_FORMAT;
-  return formatDate(date, formatOpts);
-}
-
-/**
- *
- * @description It converts `date` in `YYYY-MM-DD` format.
- */
-export function getDateString(date: Date, isUtc = true, timeZone: TimeZoneType = 'Asia/Seoul'): string {
-  return formatDate(date, { format: DATE_FORMAT, isUtc, timeZone });
-}
-
-/**
- *
- * @description It converts `date` in `YYYY-MM-DDTHH:mm:ssZ` format if isUtc is true by default.
- * Otherwise the format would be `YYYY-MM-DD HH:mm:ss`.
- */
-export function getDatetimeString(date: Date, isUtc = true, timeZone: TimeZoneType = 'Asia/Seoul'): string {
-  return formatDate(date, { isUtc, timeZone });
-}
-
-/**
- *
- * @description It converts `date` in `YYYYMMDDHHmmssSSS` format.
- */
-export function getTimestampString(date: Date, isUtc = true, timeZone: TimeZoneType = 'Asia/Seoul'): string {
-  return formatDate(date, { format: TIMESTAMP_FORMAT, isUtc, timeZone });
-}
-
-/**
- *
- * @description It converts `totalSeconds` in `hh:mm:ss` format.
- */
-export function getTimeStringFromSeconds(totalSeconds: number): string {
-  if (totalSeconds < 0) {
-    throw new Error('Invalid number');
-  }
-
-  const seconds = totalSeconds % 60;
-  const totalMinutes = (totalSeconds - seconds) / 60;
-  const minutes = totalMinutes % 60;
-  const hh = String((totalMinutes - minutes) / 60).padStart(2, '0');
-  const mm = String(minutes).padStart(2, '0');
-  const ss = String(seconds).padStart(2, '0');
-
-  return `${hh}:${mm}:${ss}`;
 }
 
 export function durationTo(duration: string, unitType: DatePropertyType = 'second'): number {

--- a/src/date-util/index.ts
+++ b/src/date-util/index.ts
@@ -6,12 +6,7 @@ export {
   endOfByTimezone,
   format12HourInLocale,
   formatDate,
-  formatInIso8601,
   fromNow,
-  getDateString,
-  getDatetimeString,
-  getTimestampString,
-  getTimeStringFromSeconds,
   getTimezoneOffsetInHours,
   getTimezoneOffsetString,
   isAdult,
@@ -26,7 +21,6 @@ export {
   startOfDate,
   subtractOneDayIfLocalTimeIsMidnight,
 } from './date-util';
-
 export type { DatePropertyType, DateType, Iso8601FormatType, LocaleType, TimeZoneType } from './date-util-base.type';
 export {
   DATE_FORMAT,

--- a/src/map-util/index.ts
+++ b/src/map-util/index.ts
@@ -1,1 +1,1 @@
-export { getMapValue, groupBy, groupByKey } from './map-util';
+export { groupBy, groupByKey } from './map-util';

--- a/src/map-util/map-util.spec.ts
+++ b/src/map-util/map-util.spec.ts
@@ -1,24 +1,4 @@
-import { getMapValue, groupBy, groupByKey } from './map-util';
-
-describe('getMapValue', () => {
-  it('should return defaultValue', () => {
-    expect(getMapValue(new Map(), 1, 'value')).toBe('value');
-  });
-
-  it('should omit defaultValue', () => {
-    expect(getMapValue(new Map(), 1)).toBeUndefined();
-  });
-
-  it('should return existing value', () => {
-    const booleanMap: Map<string, boolean> = new Map([['FALSE', false]]);
-    const nullableMap: Map<string, string | null> = new Map([['NULL', null]]);
-    const numberMap: Map<string, number> = new Map([['ZERO', 0]]);
-
-    expect(getMapValue(booleanMap, 'FALSE', true)).toBe(booleanMap.get('FALSE'));
-    expect(getMapValue(nullableMap, 'NULL')).toBe(nullableMap.get('NULL'));
-    expect(getMapValue(numberMap, 'ZERO', 1)).toBe(numberMap.get('ZERO'));
-  });
-});
+import { groupBy, groupByKey } from './map-util';
 
 describe('groupByKey', () => {
   test('should group an array of objects by a specified key', () => {

--- a/src/map-util/map-util.ts
+++ b/src/map-util/map-util.ts
@@ -1,18 +1,3 @@
-/**
- * map 에서 key 에 해당하는 값을 반환한다. 값이 undefined 이면 defaultValue 를 반환한다.
- *
- * @param map
- * @param key
- * @param defaultValue
- */
-
-export function getMapValue<K, V>(map: Map<K, V>, key: K): V | undefined;
-export function getMapValue<K, V>(map: Map<K, V>, key: K, defaultValue: V): V;
-export function getMapValue<K, V>(map: Map<K, V>, key: K, defaultValue?: V): V | undefined {
-  const value = map.get(key);
-  return value === undefined ? defaultValue : value;
-}
-
 export function groupByKey<T, K extends keyof T>(array: T[], key: K): Map<T[K], T[]> {
   return groupBy(array, (item) => item[key]);
 }

--- a/src/number-util/index.ts
+++ b/src/number-util/index.ts
@@ -1,9 +1,1 @@
-export {
-  decimalRoundDown,
-  decimalRoundUp,
-  fromPermyriad,
-  intValueOf,
-  isNumeric,
-  toPermyriad,
-  valueOfNumber,
-} from './number-util';
+export { decimalRoundDown, decimalRoundUp, fromPermyriad, intValueOf, isNumeric, toPermyriad } from './number-util';

--- a/src/number-util/number-util.spec.ts
+++ b/src/number-util/number-util.spec.ts
@@ -1,12 +1,4 @@
-import {
-  decimalRoundDown,
-  decimalRoundUp,
-  fromPermyriad,
-  intValueOf,
-  isNumeric,
-  toPermyriad,
-  valueOfNumber,
-} from './number-util';
+import { decimalRoundDown, decimalRoundUp, fromPermyriad, intValueOf, isNumeric, toPermyriad } from './number-util';
 
 describe('intValueOf', () => {
   it('should throw with incompatible input', () => {
@@ -25,23 +17,6 @@ describe('intValueOf', () => {
     expect(intValueOf(String(Number.MAX_SAFE_INTEGER))).toEqual(Number.MAX_SAFE_INTEGER);
     expect(intValueOf(String(Number.MIN_SAFE_INTEGER))).toEqual(Number.MIN_SAFE_INTEGER);
     expect(intValueOf(String(Number.MAX_VALUE))).toEqual(Number.MAX_VALUE);
-  });
-});
-
-describe('valueOfNumber', () => {
-  it('should throw with incompatible input', () => {
-    expect(() => valueOfNumber('abc')).toThrow();
-    expect(() => valueOfNumber('4a')).toThrow();
-    expect(() => valueOfNumber('1.2.3')).toThrow();
-    expect(() => valueOfNumber('')).toThrow();
-  });
-  it('should return parameter in number type', () => {
-    expect(valueOfNumber('-1')).toEqual(-1);
-    expect(valueOfNumber('0')).toEqual(0);
-    expect(valueOfNumber('1.2')).toEqual(1.2);
-    expect(valueOfNumber('-1.2')).toEqual(-1.2);
-    expect(valueOfNumber('-93339.228883747849')).toEqual(-93339.22888374786);
-    expect(valueOfNumber('9488848.29000004833')).toEqual(9488848.290000048);
   });
 });
 

--- a/src/number-util/number-util.ts
+++ b/src/number-util/number-util.ts
@@ -7,15 +7,6 @@ export function intValueOf(numStr: string): number {
   return result;
 }
 
-export function valueOfNumber(numStr: string): number {
-  const result = Number(numStr);
-
-  if (!numStr || !Number.isFinite(result)) {
-    throw new Error(`unable to convert "${numStr}" to number type`);
-  }
-  return result;
-}
-
 export function isNumeric(numStr: string): boolean {
   const num = Number(numStr);
   return !isNaN(num) && isFinite(num) && num === parseFloat(numStr);

--- a/src/object-util/object-util.ts
+++ b/src/object-util/object-util.ts
@@ -1,6 +1,7 @@
 import { ObjectKeyType, ObjectType } from './object-util.type';
 
-export function serialize(obj: Readonly<ObjectType>): string | null {
+/** @deprecated use JSON.stringify instead */
+export function serialize(obj: any): string | null {
   try {
     return JSON.stringify(obj);
   } catch {
@@ -8,7 +9,8 @@ export function serialize(obj: Readonly<ObjectType>): string | null {
   }
 }
 
-export function deserialize(str: string): ObjectType | null {
+/** @deprecated use JSON.parse instead */
+export function deserialize(str: string): any {
   try {
     return JSON.parse(str);
   } catch {
@@ -16,6 +18,7 @@ export function deserialize(str: string): ObjectType | null {
   }
 }
 
+/** @deprecated use '== null' instead */
 export function isNullish(value: unknown): value is null | undefined {
   return value === undefined || value === null;
 }
@@ -34,6 +37,7 @@ export function isEmpty(value: unknown): boolean {
   return true;
 }
 
+/** @deprecated use window.structuredClone() instead */
 export function deepClone<Type extends ObjectType>(obj: Type): Type {
   const initiator = obj.constructor as new (...arg: unknown[]) => Type;
 

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -168,7 +168,10 @@ export function isValidEmail(str: string): boolean {
 }
 
 export function splitTags(str: string, separator: string | RegExp = ','): Tag[] {
-  return str.split(separator).filter(_ => _.length).map((text) => ({ text: text.trim() }));
+  return str
+    .split(separator)
+    .map((text) => ({ text: text.trim() }))
+    .filter((_) => _.text);
 }
 
 /** @deprecated do .split().map().filter() yourself */
@@ -183,7 +186,10 @@ export function splitString(str: string, separator = ','): string[] {
 }
 
 export function joinTags(tags: Readonly<Tag[]>, separator = ','): string {
-  return tags.map((tag) => tag.text).join(separator)
+  return tags
+    .map((tag) => tag.text?.trim())
+    .filter((text) => text)
+    .join(separator);
 }
 
 /** @deprecated do .map().join() yourself */

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -167,12 +167,14 @@ export function isValidEmail(str: string): boolean {
   return EMAIL_REGEXP.test(str);
 }
 
+/** @deprecated do .split().map().filter() yourself */
 export function splitTags(str: string, separator = ','): Tag[] {
   return splitString(str, separator).map((text) => {
     return { text };
   });
 }
 
+/** @deprecated do .split().map().filter() yourself */
 export function splitString(str: string, separator = ','): string[] {
   return str.split(separator).reduce((textList: string[], text) => {
     text = text.trim();
@@ -183,6 +185,7 @@ export function splitString(str: string, separator = ','): string[] {
   }, []);
 }
 
+/** @deprecated do .map().join() yourself */
 export function joinTags(tags: Readonly<Tag[]>, separator = ','): string {
   const textList = tags.map((tag) => {
     return tag.text;
@@ -190,6 +193,7 @@ export function joinTags(tags: Readonly<Tag[]>, separator = ','): string {
   return joinStrings(textList, separator);
 }
 
+/** @deprecated do .map().join() yourself */
 export function joinStrings(textList: string[], separator = ','): string {
   return textList.reduce((joinedText: string, text) => {
     if (joinedText) {

--- a/src/string-util/string-util.ts
+++ b/src/string-util/string-util.ts
@@ -167,11 +167,8 @@ export function isValidEmail(str: string): boolean {
   return EMAIL_REGEXP.test(str);
 }
 
-/** @deprecated do .split().map().filter() yourself */
-export function splitTags(str: string, separator = ','): Tag[] {
-  return splitString(str, separator).map((text) => {
-    return { text };
-  });
+export function splitTags(str: string, separator: string | RegExp = ','): Tag[] {
+  return str.split(separator).filter(_ => _.length).map((text) => ({ text: text.trim() }));
 }
 
 /** @deprecated do .split().map().filter() yourself */
@@ -185,12 +182,8 @@ export function splitString(str: string, separator = ','): string[] {
   }, []);
 }
 
-/** @deprecated do .map().join() yourself */
 export function joinTags(tags: Readonly<Tag[]>, separator = ','): string {
-  const textList = tags.map((tag) => {
-    return tag.text;
-  });
-  return joinStrings(textList, separator);
+  return tags.map((tag) => tag.text).join(separator)
 }
 
 /** @deprecated do .map().join() yourself */

--- a/src/unit-util/unit-converters/byte-unit-converter.ts
+++ b/src/unit-util/unit-converters/byte-unit-converter.ts
@@ -30,7 +30,7 @@ class ByteUnitConverter implements UnitConverter<ByteUnitType> {
     return this.toString(converted, outputUnit);
   }
 
-  private toString(value: number, outputUnit: ByteUnitType): string {
+  public toString(value: number, outputUnit: ByteUnitType): string {
     const retValue = value < 1 ? value : Math.round(value);
     return `${retValue} ${this.byteUnitNotationMap[outputUnit]}`;
   }


### PR DESCRIPTION
#243 에 머지하는 PR입니다

오래되었거나, 대체하는 기능이 생겼거나, 중복되거나, 쓰이지 않는 method들을 대량 정리합니다

### 명단

- boolean-util / `valueOf` -> `parseBoolean`
  안 쓰이는 줄 알았는데 환경변수 해석할 때 꽤 많이 쓰이고 있었습니다… 더 나은 이름으로 갱신합니다

- map-util / `get` -> **삭제**
  Map#get과 중복됩니다.

- number-util / `valueOfNumber` -> **삭제**
  사용 0건. 대부분 위에 있는 (int)valueOf를 사용하고 있습니다.

- object-util / `serialize`, `deserialize` -> **deprecated**
  겸사겸사 잘못 지정되어 있는 타입을 수정합니다. (JSON.parse는 직렬화될 수 있는 아무 타입이나 리턴할 수 있습니다)

- object-util / `isNullish` -> **deprecated**
  `== null`을 권장합니다.

- object-util / `deepClone` -> **deprecated**
  [`structuredClone`](https://developer.mozilla.org/ko/docs/Web/API/Window/structuredClone)을 권장합니다.

- string-util / `splitString`, `joinStrings` -> **deprecated**
  …